### PR TITLE
Disable one more warning message

### DIFF
--- a/Eigen/src/Core/util/DisableStupidWarnings.h
+++ b/Eigen/src/Core/util/DisableStupidWarnings.h
@@ -90,6 +90,7 @@
   #pragma diag_suppress 2735
   #pragma diag_suppress 2737
   #pragma diag_suppress 2739
+  #pragma diag_suppress 20014
 #endif
 
 #else


### PR DESCRIPTION
Disable one more "calling a `__host__` function from a `__host__` `__device__` function is not allowed" message.