### PR TITLE
Re-import and update of Eigen patches for CUDA

### DIFF
--- a/Eigen/src/Cholesky/LDLT.h
+++ b/Eigen/src/Cholesky/LDLT.h
@@ -82,6 +82,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * The default constructor is useful in cases in which the user intends to
       * perform decompositions via LDLT::compute(const MatrixType&).
       */
+    EIGEN_DEVICE_FUNC
     LDLT()
       : m_matrix(),
         m_transpositions(),
@@ -95,6 +96,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * according to the specified problem \a size.
       * \sa LDLT()
       */
+    EIGEN_DEVICE_FUNC
     explicit LDLT(Index size)
       : m_matrix(size, size),
         m_transpositions(size),
@@ -110,6 +112,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * \sa LDLT(Index size)
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit LDLT(const EigenBase<InputType>& matrix)
       : m_matrix(matrix.rows(), matrix.cols()),
         m_transpositions(matrix.rows()),
@@ -127,6 +130,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * \sa LDLT(const EigenBase&)
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit LDLT(EigenBase<InputType>& matrix)
       : m_matrix(matrix.derived()),
         m_transpositions(matrix.rows()),
@@ -140,12 +144,14 @@ template<typename _MatrixType, int _UpLo> class LDLT
     /** Clear any existing decomposition
      * \sa rankUpdate(w,sigma)
      */
+    EIGEN_DEVICE_FUNC
     void setZero()
     {
       m_isInitialized = false;
     }
 
     /** \returns a view of the upper triangular matrix U */
+    EIGEN_DEVICE_FUNC
     inline typename Traits::MatrixU matrixU() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -153,6 +159,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
     }
 
     /** \returns a view of the lower triangular matrix L */
+    EIGEN_DEVICE_FUNC
     inline typename Traits::MatrixL matrixL() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -161,6 +168,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
 
     /** \returns the permutation matrix P as a transposition sequence.
       */
+    EIGEN_DEVICE_FUNC
     inline const TranspositionType& transpositionsP() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -168,6 +176,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
     }
 
     /** \returns the coefficients of the diagonal matrix D */
+    EIGEN_DEVICE_FUNC
     inline Diagonal<const MatrixType> vectorD() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -175,6 +184,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
     }
 
     /** \returns true if the matrix is positive (semidefinite) */
+    EIGEN_DEVICE_FUNC
     inline bool isPositive() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -182,6 +192,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
     }
 
     /** \returns true if the matrix is negative (semidefinite) */
+    EIGEN_DEVICE_FUNC
     inline bool isNegative(void) const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -205,19 +216,23 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * \sa MatrixBase::ldlt(), SelfAdjointView::ldlt()
       */
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<LDLT, Rhs>
     solve(const MatrixBase<Rhs>& b) const;
     #endif
 
     template<typename Derived>
+    EIGEN_DEVICE_FUNC
     bool solveInPlace(MatrixBase<Derived> &bAndX) const;
 
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     LDLT& compute(const EigenBase<InputType>& matrix);
 
     /** \returns an estimate of the reciprocal condition number of the matrix of
      *  which \c *this is the LDLT decomposition.
      */
+    EIGEN_DEVICE_FUNC
     RealScalar rcond() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -225,18 +240,21 @@ template<typename _MatrixType, int _UpLo> class LDLT
     }
 
     template <typename Derived>
+    EIGEN_DEVICE_FUNC
     LDLT& rankUpdate(const MatrixBase<Derived>& w, const RealScalar& alpha=1);
 
     /** \returns the internal LDLT decomposition matrix
       *
       * TODO: document the storage layout
       */
+    EIGEN_DEVICE_FUNC
     inline const MatrixType& matrixLDLT() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
       return m_matrix;
     }
 
+    EIGEN_DEVICE_FUNC
     MatrixType reconstructedMatrix() const;
 
     /** \returns the adjoint of \c *this, that is, a const reference to the decomposition itself as the underlying matrix is self-adjoint.
@@ -244,6 +262,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * This method is provided for compatibility with other matrix decompositions, thus enabling generic code such as:
       * \code x = decomposition.adjoint().solve(b) \endcode
       */
+    EIGEN_DEVICE_FUNC
     const LDLT& adjoint() const { return *this; };
 
     inline Index rows() const { return m_matrix.rows(); }
@@ -254,6 +273,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
       * \returns \c Success if computation was successful,
       *          \c NumericalIssue if the factorization failed because of a zero pivot.
       */
+    EIGEN_DEVICE_FUNC
     ComputationInfo info() const
     {
       eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -262,6 +282,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
 
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename RhsType, typename DstType>
+    EIGEN_DEVICE_FUNC
     void _solve_impl(const RhsType &rhs, DstType &dst) const;
 
     template<bool Conjugate, typename RhsType, typename DstType>
@@ -270,6 +291,7 @@ template<typename _MatrixType, int _UpLo> class LDLT
 
   protected:
 
+    EIGEN_DEVICE_FUNC
     static void check_template_parameters()
     {
       EIGEN_STATIC_ASSERT_NON_INTEGER(Scalar);
@@ -297,6 +319,7 @@ template<int UpLo> struct ldlt_inplace;
 template<> struct ldlt_inplace<Lower>
 {
   template<typename MatrixType, typename TranspositionType, typename Workspace>
+  EIGEN_DEVICE_FUNC
   static bool unblocked(MatrixType& mat, TranspositionType& transpositions, Workspace& temp, SignMatrix& sign)
   {
     using std::abs;
@@ -333,7 +356,7 @@ template<> struct ldlt_inplace<Lower>
         Index s = size-index_of_biggest_in_corner-1; // trailing size after the biggest element
         mat.row(k).head(k).swap(mat.row(index_of_biggest_in_corner).head(k));
         mat.col(k).tail(s).swap(mat.col(index_of_biggest_in_corner).tail(s));
-        std::swap(mat.coeffRef(k,k),mat.coeffRef(index_of_biggest_in_corner,index_of_biggest_in_corner));
+        numext::swap(mat.coeffRef(k,k),mat.coeffRef(index_of_biggest_in_corner,index_of_biggest_in_corner));
         for(Index i=k+1;i<index_of_biggest_in_corner;++i)
         {
           Scalar tmp = mat.coeffRef(i,k);
@@ -410,6 +433,7 @@ template<> struct ldlt_inplace<Lower>
   // Here only rank-1 updates are implemented, to reduce the
   // requirement for intermediate storage and improve accuracy
   template<typename MatrixType, typename WDerived>
+  EIGEN_DEVICE_FUNC
   static bool updateInPlace(MatrixType& mat, MatrixBase<WDerived>& w, const typename MatrixType::RealScalar& sigma=1)
   {
     using numext::isfinite;
@@ -448,6 +472,7 @@ template<> struct ldlt_inplace<Lower>
   }
 
   template<typename MatrixType, typename TranspositionType, typename Workspace, typename WType>
+  EIGEN_DEVICE_FUNC
   static bool update(MatrixType& mat, const TranspositionType& transpositions, Workspace& tmp, const WType& w, const typename MatrixType::RealScalar& sigma=1)
   {
     // Apply the permutation to the input w
@@ -460,6 +485,7 @@ template<> struct ldlt_inplace<Lower>
 template<> struct ldlt_inplace<Upper>
 {
   template<typename MatrixType, typename TranspositionType, typename Workspace>
+  EIGEN_DEVICE_FUNC
   static EIGEN_STRONG_INLINE bool unblocked(MatrixType& mat, TranspositionType& transpositions, Workspace& temp, SignMatrix& sign)
   {
     Transpose<MatrixType> matt(mat);
@@ -467,6 +493,7 @@ template<> struct ldlt_inplace<Upper>
   }
 
   template<typename MatrixType, typename TranspositionType, typename Workspace, typename WType>
+  EIGEN_DEVICE_FUNC
   static EIGEN_STRONG_INLINE bool update(MatrixType& mat, TranspositionType& transpositions, Workspace& tmp, WType& w, const typename MatrixType::RealScalar& sigma=1)
   {
     Transpose<MatrixType> matt(mat);
@@ -478,7 +505,9 @@ template<typename MatrixType> struct LDLT_Traits<MatrixType,Lower>
 {
   typedef const TriangularView<const MatrixType, UnitLower> MatrixL;
   typedef const TriangularView<const typename MatrixType::AdjointReturnType, UnitUpper> MatrixU;
+  EIGEN_DEVICE_FUNC
   static inline MatrixL getL(const MatrixType& m) { return MatrixL(m); }
+  EIGEN_DEVICE_FUNC
   static inline MatrixU getU(const MatrixType& m) { return MatrixU(m.adjoint()); }
 };
 
@@ -486,7 +515,9 @@ template<typename MatrixType> struct LDLT_Traits<MatrixType,Upper>
 {
   typedef const TriangularView<const typename MatrixType::AdjointReturnType, UnitLower> MatrixL;
   typedef const TriangularView<const MatrixType, UnitUpper> MatrixU;
+  EIGEN_DEVICE_FUNC
   static inline MatrixL getL(const MatrixType& m) { return MatrixL(m.adjoint()); }
+  EIGEN_DEVICE_FUNC
   static inline MatrixU getU(const MatrixType& m) { return MatrixU(m); }
 };
 
@@ -496,6 +527,7 @@ template<typename MatrixType> struct LDLT_Traits<MatrixType,Upper>
   */
 template<typename MatrixType, int _UpLo>
 template<typename InputType>
+EIGEN_DEVICE_FUNC
 LDLT<MatrixType,_UpLo>& LDLT<MatrixType,_UpLo>::compute(const EigenBase<InputType>& a)
 {
   check_template_parameters();
@@ -536,6 +568,7 @@ LDLT<MatrixType,_UpLo>& LDLT<MatrixType,_UpLo>::compute(const EigenBase<InputTyp
   */
 template<typename MatrixType, int _UpLo>
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 LDLT<MatrixType,_UpLo>& LDLT<MatrixType,_UpLo>::rankUpdate(const MatrixBase<Derived>& w, const typename LDLT<MatrixType,_UpLo>::RealScalar& sigma)
 {
   typedef typename TranspositionType::StorageIndex IndexType;
@@ -564,6 +597,7 @@ LDLT<MatrixType,_UpLo>& LDLT<MatrixType,_UpLo>::rankUpdate(const MatrixBase<Deri
 #ifndef EIGEN_PARSED_BY_DOXYGEN
 template<typename _MatrixType, int _UpLo>
 template<typename RhsType, typename DstType>
+EIGEN_DEVICE_FUNC
 void LDLT<_MatrixType,_UpLo>::_solve_impl(const RhsType &rhs, DstType &dst) const
 {
   _solve_impl_transposed<true>(rhs, dst);
@@ -626,6 +660,7 @@ void LDLT<_MatrixType,_UpLo>::_solve_impl_transposed(const RhsType &rhs, DstType
   */
 template<typename MatrixType,int _UpLo>
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 bool LDLT<MatrixType,_UpLo>::solveInPlace(MatrixBase<Derived> &bAndX) const
 {
   eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -640,6 +675,7 @@ bool LDLT<MatrixType,_UpLo>::solveInPlace(MatrixBase<Derived> &bAndX) const
  * i.e., it returns the product: P^T L D L^* P.
  * This function is provided for debug purpose. */
 template<typename MatrixType, int _UpLo>
+EIGEN_DEVICE_FUNC
 MatrixType LDLT<MatrixType,_UpLo>::reconstructedMatrix() const
 {
   eigen_assert(m_isInitialized && "LDLT is not initialized.");
@@ -666,6 +702,7 @@ MatrixType LDLT<MatrixType,_UpLo>::reconstructedMatrix() const
   * \sa MatrixBase::ldlt()
   */
 template<typename MatrixType, unsigned int UpLo>
+EIGEN_DEVICE_FUNC
 inline const LDLT<typename SelfAdjointView<MatrixType, UpLo>::PlainObject, UpLo>
 SelfAdjointView<MatrixType, UpLo>::ldlt() const
 {
@@ -677,6 +714,7 @@ SelfAdjointView<MatrixType, UpLo>::ldlt() const
   * \sa SelfAdjointView::ldlt()
   */
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 inline const LDLT<typename MatrixBase<Derived>::PlainObject>
 MatrixBase<Derived>::ldlt() const
 {

--- a/Eigen/src/Cholesky/LLT.h
+++ b/Eigen/src/Cholesky/LLT.h
@@ -90,7 +90,7 @@ template<typename _MatrixType, int _UpLo> class LLT
       * The default constructor is useful in cases in which the user intends to
       * perform decompositions via LLT::compute(const MatrixType&).
       */
-    LLT() : m_matrix(), m_isInitialized(false) {}
+    EIGEN_DEVICE_FUNC LLT() : m_matrix(), m_isInitialized(false) {}
 
     /** \brief Default Constructor with memory preallocation
       *
@@ -98,10 +98,11 @@ template<typename _MatrixType, int _UpLo> class LLT
       * according to the specified problem \a size.
       * \sa LLT()
       */
-    explicit LLT(Index size) : m_matrix(size, size),
+    EIGEN_DEVICE_FUNC explicit LLT(Index size) : m_matrix(size, size),
                     m_isInitialized(false) {}
 
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit LLT(const EigenBase<InputType>& matrix)
       : m_matrix(matrix.rows(), matrix.cols()),
         m_isInitialized(false)
@@ -117,6 +118,7 @@ template<typename _MatrixType, int _UpLo> class LLT
       * \sa LLT(const EigenBase&)
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit LLT(EigenBase<InputType>& matrix)
       : m_matrix(matrix.derived()),
         m_isInitialized(false)
@@ -125,6 +127,7 @@ template<typename _MatrixType, int _UpLo> class LLT
     }
 
     /** \returns a view of the upper triangular matrix U */
+    EIGEN_DEVICE_FUNC
     inline typename Traits::MatrixU matrixU() const
     {
       eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -132,6 +135,7 @@ template<typename _MatrixType, int _UpLo> class LLT
     }
 
     /** \returns a view of the lower triangular matrix L */
+    EIGEN_DEVICE_FUNC
     inline typename Traits::MatrixL matrixL() const
     {
       eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -151,18 +155,22 @@ template<typename _MatrixType, int _UpLo> class LLT
       */
     template<typename Rhs>
     inline const Solve<LLT, Rhs>
+    EIGEN_DEVICE_FUNC
     solve(const MatrixBase<Rhs>& b) const;
     #endif
 
     template<typename Derived>
+    EIGEN_DEVICE_FUNC
     void solveInPlace(const MatrixBase<Derived> &bAndX) const;
 
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     LLT& compute(const EigenBase<InputType>& matrix);
 
     /** \returns an estimate of the reciprocal condition number of the matrix of
       *  which \c *this is the Cholesky decomposition.
       */
+    EIGEN_DEVICE_FUNC
     RealScalar rcond() const
     {
       eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -174,12 +182,14 @@ template<typename _MatrixType, int _UpLo> class LLT
       *
       * TODO: document the storage layout
       */
+    EIGEN_DEVICE_FUNC
     inline const MatrixType& matrixLLT() const
     {
       eigen_assert(m_isInitialized && "LLT is not initialized.");
       return m_matrix;
     }
 
+    EIGEN_DEVICE_FUNC
     MatrixType reconstructedMatrix() const;
 
 
@@ -188,6 +198,7 @@ template<typename _MatrixType, int _UpLo> class LLT
       * \returns \c Success if computation was successful,
       *          \c NumericalIssue if the matrix.appears not to be positive definite.
       */
+    EIGEN_DEVICE_FUNC
     ComputationInfo info() const
     {
       eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -199,16 +210,21 @@ template<typename _MatrixType, int _UpLo> class LLT
       * This method is provided for compatibility with other matrix decompositions, thus enabling generic code such as:
       * \code x = decomposition.adjoint().solve(b) \endcode
       */
-    const LLT& adjoint() const { return *this; };
+    EIGEN_DEVICE_FUNC
+    const LLT& adjoint() const EIGEN_NOEXCEPT { return *this; };
 
-    inline Index rows() const { return m_matrix.rows(); }
-    inline Index cols() const { return m_matrix.cols(); }
+    EIGEN_DEVICE_FUNC
+    inline EIGEN_CONSTEXPR Index rows() const EIGEN_NOEXCEPT { return m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
+    inline EIGEN_CONSTEXPR Index cols() const EIGEN_NOEXCEPT { return m_matrix.cols(); }
 
     template<typename VectorType>
+    EIGEN_DEVICE_FUNC
     LLT & rankUpdate(const VectorType& vec, const RealScalar& sigma = 1);
 
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename RhsType, typename DstType>
+    EIGEN_DEVICE_FUNC
     void _solve_impl(const RhsType &rhs, DstType &dst) const;
 
     template<bool Conjugate, typename RhsType, typename DstType>
@@ -217,6 +233,7 @@ template<typename _MatrixType, int _UpLo> class LLT
 
   protected:
 
+    EIGEN_DEVICE_FUNC
     static void check_template_parameters()
     {
       EIGEN_STATIC_ASSERT_NON_INTEGER(Scalar);
@@ -237,6 +254,7 @@ namespace internal {
 template<typename Scalar, int UpLo> struct llt_inplace;
 
 template<typename MatrixType, typename VectorType>
+EIGEN_DEVICE_FUNC
 static Index llt_rank_update_lower(MatrixType& mat, const VectorType& vec, const typename MatrixType::RealScalar& sigma)
 {
   using std::sqrt;
@@ -310,6 +328,7 @@ template<typename Scalar> struct llt_inplace<Scalar, Lower>
 {
   typedef typename NumTraits<Scalar>::Real RealScalar;
   template<typename MatrixType>
+  EIGEN_DEVICE_FUNC
   static Index unblocked(MatrixType& mat)
   {
     using std::sqrt;
@@ -336,6 +355,7 @@ template<typename Scalar> struct llt_inplace<Scalar, Lower>
   }
 
   template<typename MatrixType>
+  EIGEN_DEVICE_FUNC
   static Index blocked(MatrixType& m)
   {
     eigen_assert(m.rows()==m.cols());
@@ -368,6 +388,7 @@ template<typename Scalar> struct llt_inplace<Scalar, Lower>
   }
 
   template<typename MatrixType, typename VectorType>
+  EIGEN_DEVICE_FUNC
   static Index rankUpdate(MatrixType& mat, const VectorType& vec, const RealScalar& sigma)
   {
     return Eigen::internal::llt_rank_update_lower(mat, vec, sigma);
@@ -379,18 +400,21 @@ template<typename Scalar> struct llt_inplace<Scalar, Upper>
   typedef typename NumTraits<Scalar>::Real RealScalar;
 
   template<typename MatrixType>
+  EIGEN_DEVICE_FUNC
   static EIGEN_STRONG_INLINE Index unblocked(MatrixType& mat)
   {
     Transpose<MatrixType> matt(mat);
     return llt_inplace<Scalar, Lower>::unblocked(matt);
   }
   template<typename MatrixType>
+  EIGEN_DEVICE_FUNC
   static EIGEN_STRONG_INLINE Index blocked(MatrixType& mat)
   {
     Transpose<MatrixType> matt(mat);
     return llt_inplace<Scalar, Lower>::blocked(matt);
   }
   template<typename MatrixType, typename VectorType>
+  EIGEN_DEVICE_FUNC
   static Index rankUpdate(MatrixType& mat, const VectorType& vec, const RealScalar& sigma)
   {
     Transpose<MatrixType> matt(mat);
@@ -402,9 +426,9 @@ template<typename MatrixType> struct LLT_Traits<MatrixType,Lower>
 {
   typedef const TriangularView<const MatrixType, Lower> MatrixL;
   typedef const TriangularView<const typename MatrixType::AdjointReturnType, Upper> MatrixU;
-  static inline MatrixL getL(const MatrixType& m) { return MatrixL(m); }
-  static inline MatrixU getU(const MatrixType& m) { return MatrixU(m.adjoint()); }
-  static bool inplace_decomposition(MatrixType& m)
+  EIGEN_DEVICE_FUNC static inline MatrixL getL(const MatrixType& m) { return MatrixL(m); }
+  EIGEN_DEVICE_FUNC static inline MatrixU getU(const MatrixType& m) { return MatrixU(m.adjoint()); }
+  EIGEN_DEVICE_FUNC static bool inplace_decomposition(MatrixType& m)
   { return llt_inplace<typename MatrixType::Scalar, Lower>::blocked(m)==-1; }
 };
 
@@ -412,9 +436,9 @@ template<typename MatrixType> struct LLT_Traits<MatrixType,Upper>
 {
   typedef const TriangularView<const typename MatrixType::AdjointReturnType, Lower> MatrixL;
   typedef const TriangularView<const MatrixType, Upper> MatrixU;
-  static inline MatrixL getL(const MatrixType& m) { return MatrixL(m.adjoint()); }
-  static inline MatrixU getU(const MatrixType& m) { return MatrixU(m); }
-  static bool inplace_decomposition(MatrixType& m)
+  EIGEN_DEVICE_FUNC static inline MatrixL getL(const MatrixType& m) { return MatrixL(m.adjoint()); }
+  EIGEN_DEVICE_FUNC static inline MatrixU getU(const MatrixType& m) { return MatrixU(m); }
+  EIGEN_DEVICE_FUNC static bool inplace_decomposition(MatrixType& m)
   { return llt_inplace<typename MatrixType::Scalar, Upper>::blocked(m)==-1; }
 };
 
@@ -429,6 +453,7 @@ template<typename MatrixType> struct LLT_Traits<MatrixType,Upper>
   */
 template<typename MatrixType, int _UpLo>
 template<typename InputType>
+EIGEN_DEVICE_FUNC
 LLT<MatrixType,_UpLo>& LLT<MatrixType,_UpLo>::compute(const EigenBase<InputType>& a)
 {
   check_template_parameters();
@@ -466,6 +491,7 @@ LLT<MatrixType,_UpLo>& LLT<MatrixType,_UpLo>::compute(const EigenBase<InputType>
   */
 template<typename _MatrixType, int _UpLo>
 template<typename VectorType>
+EIGEN_DEVICE_FUNC
 LLT<_MatrixType,_UpLo> & LLT<_MatrixType,_UpLo>::rankUpdate(const VectorType& v, const RealScalar& sigma)
 {
   EIGEN_STATIC_ASSERT_VECTOR_ONLY(VectorType);
@@ -482,6 +508,7 @@ LLT<_MatrixType,_UpLo> & LLT<_MatrixType,_UpLo>::rankUpdate(const VectorType& v,
 #ifndef EIGEN_PARSED_BY_DOXYGEN
 template<typename _MatrixType,int _UpLo>
 template<typename RhsType, typename DstType>
+EIGEN_DEVICE_FUNC
 void LLT<_MatrixType,_UpLo>::_solve_impl(const RhsType &rhs, DstType &dst) const
 {
   _solve_impl_transposed<true>(rhs, dst);
@@ -513,6 +540,7 @@ void LLT<_MatrixType,_UpLo>::_solve_impl_transposed(const RhsType &rhs, DstType 
   */
 template<typename MatrixType, int _UpLo>
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 void LLT<MatrixType,_UpLo>::solveInPlace(const MatrixBase<Derived> &bAndX) const
 {
   eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -525,6 +553,7 @@ void LLT<MatrixType,_UpLo>::solveInPlace(const MatrixBase<Derived> &bAndX) const
  * i.e., it returns the product: L L^*.
  * This function is provided for debug purpose. */
 template<typename MatrixType, int _UpLo>
+EIGEN_DEVICE_FUNC
 MatrixType LLT<MatrixType,_UpLo>::reconstructedMatrix() const
 {
   eigen_assert(m_isInitialized && "LLT is not initialized.");
@@ -537,6 +566,7 @@ MatrixType LLT<MatrixType,_UpLo>::reconstructedMatrix() const
   */
 template<typename Derived>
 inline const LLT<typename MatrixBase<Derived>::PlainObject>
+EIGEN_DEVICE_FUNC
 MatrixBase<Derived>::llt() const
 {
   return LLT<PlainObject>(derived());
@@ -547,6 +577,7 @@ MatrixBase<Derived>::llt() const
   * \sa SelfAdjointView::llt()
   */
 template<typename MatrixType, unsigned int UpLo>
+EIGEN_DEVICE_FUNC
 inline const LLT<typename SelfAdjointView<MatrixType, UpLo>::PlainObject, UpLo>
 SelfAdjointView<MatrixType, UpLo>::llt() const
 {

--- a/Eigen/src/Core/CoreEvaluators.h
+++ b/Eigen/src/Core/CoreEvaluators.h
@@ -229,7 +229,7 @@ struct evaluator<PlainObjectBase<Derived> >
   }
 
   template<int LoadMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   PacketType packet(Index row, Index col) const
   {
     if (IsRowMajor)
@@ -239,14 +239,14 @@ struct evaluator<PlainObjectBase<Derived> >
   }
 
   template<int LoadMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   PacketType packet(Index index) const
   {
     return ploadt<PacketType, LoadMode>(m_d.data + index);
   }
 
   template<int StoreMode,typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   void writePacket(Index row, Index col, const PacketType& x)
   {
     if (IsRowMajor)
@@ -258,7 +258,7 @@ struct evaluator<PlainObjectBase<Derived> >
   }
 
   template<int StoreMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   void writePacket(Index index, const PacketType& x)
   {
     return pstoret<Scalar, PacketType, StoreMode>(const_cast<Scalar*>(m_d.data) + index, x);
@@ -344,28 +344,28 @@ struct unary_evaluator<Transpose<ArgType>, IndexBased>
   }
 
   template<int LoadMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   PacketType packet(Index row, Index col) const
   {
     return m_argImpl.template packet<LoadMode,PacketType>(col, row);
   }
 
   template<int LoadMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   PacketType packet(Index index) const
   {
     return m_argImpl.template packet<LoadMode,PacketType>(index);
   }
 
   template<int StoreMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   void writePacket(Index row, Index col, const PacketType& x)
   {
     m_argImpl.template writePacket<StoreMode,PacketType>(col, row, x);
   }
 
   template<int StoreMode, typename PacketType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   void writePacket(Index index, const PacketType& x)
   {
     m_argImpl.template writePacket<StoreMode,PacketType>(index, x);
@@ -534,14 +534,14 @@ struct evaluator<CwiseNullaryOp<NullaryOp,PlainObjectType> >
   }
 
   template<int LoadMode, typename PacketType, typename IndexType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   PacketType packet(IndexType row, IndexType col) const
   {
     return m_wrapper.template packetOp<PacketType>(m_functor, row, col);
   }
 
   template<int LoadMode, typename PacketType, typename IndexType>
-  EIGEN_STRONG_INLINE
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   PacketType packet(IndexType index) const
   {
     return m_wrapper.template packetOp<PacketType>(m_functor, index);

--- a/Eigen/src/Core/DenseStorage.h
+++ b/Eigen/src/Core/DenseStorage.h
@@ -573,9 +573,9 @@ template<typename T, int _Cols, int _Options> class DenseStorage<T, Dynamic, Dyn
       numext::swap(m_data,other.m_data);
       numext::swap(m_rows,other.m_rows);
     }
-    EIGEN_DEVICE_FUNC Index rows(void) const {return m_rows;}
-    EIGEN_DEVICE_FUNC static Index cols(void) {return _Cols;}
-    void conservativeResize(Index size, Index rows, Index)
+    EIGEN_DEVICE_FUNC Index rows(void) const EIGEN_NOEXCEPT {return m_rows;}
+    EIGEN_DEVICE_FUNC static EIGEN_CONSTEXPR Index cols(void) {return _Cols;}
+    EIGEN_DEVICE_FUNC void conservativeResize(Index size, Index rows, Index)
     {
       m_data = internal::conditional_aligned_realloc_new_auto<T,(_Options&DontAlign)==0>(m_data, size, m_rows*_Cols);
       m_rows = rows;

--- a/Eigen/src/Core/DiagonalMatrix.h
+++ b/Eigen/src/Core/DiagonalMatrix.h
@@ -366,6 +366,7 @@ template<> struct AssignmentKind<DenseShape,DiagonalShape> { typedef Diagonal2De
 template< typename DstXprType, typename SrcXprType, typename Functor>
 struct Assignment<DstXprType, SrcXprType, Functor, Diagonal2Dense>
 {
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   {
     Index dstRows = src.rows();
@@ -377,9 +378,11 @@ struct Assignment<DstXprType, SrcXprType, Functor, Diagonal2Dense>
     dst.diagonal() = src.diagonal();
   }
   
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::add_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   { dst.diagonal() += src.diagonal(); }
   
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::sub_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   { dst.diagonal() -= src.diagonal(); }
 };

--- a/Eigen/src/Core/DiagonalMatrix.h
+++ b/Eigen/src/Core/DiagonalMatrix.h
@@ -336,6 +336,7 @@ MatrixBase<Derived>::asDiagonal() const
   * \sa asDiagonal()
   */
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 bool MatrixBase<Derived>::isDiagonal(const RealScalar& prec) const
 {
   if(cols() != rows()) return false;

--- a/Eigen/src/Core/GeneralProduct.h
+++ b/Eigen/src/Core/GeneralProduct.h
@@ -181,11 +181,13 @@ struct gemv_static_vector_if<Scalar,Size,MaxSize,true>
   };
   #if EIGEN_MAX_STATIC_ALIGN_BYTES!=0
   internal::plain_array<Scalar,EIGEN_SIZE_MIN_PREFER_FIXED(Size,MaxSize),0,EIGEN_PLAIN_ENUM_MIN(AlignedMax,PacketSize)> m_data;
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE Scalar* data() { return m_data.array; }
   #else
   // Some architectures cannot align on the stack,
   // => let's manually enforce alignment by allocating more data and return the address of the first aligned element.
   internal::plain_array<Scalar,EIGEN_SIZE_MIN_PREFER_FIXED(Size,MaxSize)+(ForceAlignment?EIGEN_MAX_ALIGN_BYTES:0),0> m_data;
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE Scalar* data() {
     return ForceAlignment
             ? reinterpret_cast<Scalar*>((internal::UIntPtr(m_data.array) & ~(std::size_t(EIGEN_MAX_ALIGN_BYTES-1))) + EIGEN_MAX_ALIGN_BYTES)
@@ -199,6 +201,7 @@ template<int StorageOrder, bool BlasCompatible>
 struct gemv_dense_selector<OnTheLeft,StorageOrder,BlasCompatible>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     Transpose<Dest> destT(dest);
@@ -211,6 +214,7 @@ struct gemv_dense_selector<OnTheLeft,StorageOrder,BlasCompatible>
 template<> struct gemv_dense_selector<OnTheRight,ColMajor,true>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static inline void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     typedef typename Lhs::Scalar   LhsScalar;
@@ -305,6 +309,7 @@ template<> struct gemv_dense_selector<OnTheRight,ColMajor,true>
 template<> struct gemv_dense_selector<OnTheRight,RowMajor,true>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     typedef typename Lhs::Scalar   LhsScalar;
@@ -358,6 +363,7 @@ template<> struct gemv_dense_selector<OnTheRight,RowMajor,true>
 template<> struct gemv_dense_selector<OnTheRight,ColMajor,false>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     EIGEN_STATIC_ASSERT((!nested_eval<Lhs,1>::Evaluate),EIGEN_INTERNAL_COMPILATION_ERROR_OR_YOU_MADE_A_PROGRAMMING_MISTAKE);
@@ -372,6 +378,7 @@ template<> struct gemv_dense_selector<OnTheRight,ColMajor,false>
 template<> struct gemv_dense_selector<OnTheRight,RowMajor,false>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     EIGEN_STATIC_ASSERT((!nested_eval<Lhs,1>::Evaluate),EIGEN_INTERNAL_COMPILATION_ERROR_OR_YOU_MADE_A_PROGRAMMING_MISTAKE);

--- a/Eigen/src/Core/IndexedView.h
+++ b/Eigen/src/Core/IndexedView.h
@@ -117,28 +117,35 @@ public:
   typedef typename internal::remove_all<XprType>::type NestedExpression;
 
   template<typename T0, typename T1>
+  EIGEN_DEVICE_FUNC
   IndexedView(XprType& xpr, const T0& rowIndices, const T1& colIndices)
     : m_xpr(xpr), m_rowIndices(rowIndices), m_colIndices(colIndices)
   {}
 
   /** \returns number of rows */
+  EIGEN_DEVICE_FUNC
   Index rows() const { return internal::size(m_rowIndices); }
 
   /** \returns number of columns */
+  EIGEN_DEVICE_FUNC
   Index cols() const { return internal::size(m_colIndices); }
 
   /** \returns the nested expression */
+  EIGEN_DEVICE_FUNC
   const typename internal::remove_all<XprType>::type&
   nestedExpression() const { return m_xpr; }
 
   /** \returns the nested expression */
+  EIGEN_DEVICE_FUNC
   typename internal::remove_reference<XprType>::type&
   nestedExpression() { return m_xpr; }
 
   /** \returns a const reference to the object storing/generating the row indices */
+  EIGEN_DEVICE_FUNC
   const RowIndices& rowIndices() const { return m_rowIndices; }
 
   /** \returns a const reference to the object storing/generating the column indices */
+  EIGEN_DEVICE_FUNC
   const ColIndices& colIndices() const { return m_colIndices; }
 
 protected:

--- a/Eigen/src/Core/MatrixBase.h
+++ b/Eigen/src/Core/MatrixBase.h
@@ -324,6 +324,8 @@ template<typename Derived> class MatrixBase
 /////////// LU module ///////////
 
     inline const FullPivLU<PlainObject> fullPivLu() const;
+
+    EIGEN_DEVICE_FUNC
     inline const PartialPivLU<PlainObject> partialPivLu() const;
 
     inline const PartialPivLU<PlainObject> lu() const;

--- a/Eigen/src/Core/MatrixBase.h
+++ b/Eigen/src/Core/MatrixBase.h
@@ -171,12 +171,15 @@ template<typename Derived> class MatrixBase
     lazyProduct(const MatrixBase<OtherDerived> &other) const;
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator*=(const EigenBase<OtherDerived>& other);
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     void applyOnTheLeft(const EigenBase<OtherDerived>& other);
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     void applyOnTheRight(const EigenBase<OtherDerived>& other);
 
     template<typename DiagonalDerived>
@@ -249,6 +252,7 @@ template<typename Derived> class MatrixBase
     EIGEN_DEVICE_FUNC
     typename ConstSelfAdjointViewReturnType<UpLo>::Type selfadjointView() const;
 
+    EIGEN_DEVICE_FUNC
     const SparseView<Derived> sparseView(const Scalar& m_reference = Scalar(0),
                                          const typename NumTraits<Scalar>::Real& m_epsilon = NumTraits<Scalar>::dummy_precision()) const;
     EIGEN_DEVICE_FUNC static const IdentityReturnType Identity();
@@ -262,6 +266,7 @@ template<typename Derived> class MatrixBase
 
     EIGEN_DEVICE_FUNC
     const DiagonalWrapper<const Derived> asDiagonal() const;
+    EIGEN_DEVICE_FUNC
     const PermutationWrapper<const Derived> asPermutation() const;
 
     EIGEN_DEVICE_FUNC
@@ -272,6 +277,7 @@ template<typename Derived> class MatrixBase
     EIGEN_DEVICE_FUNC Derived& setUnit(Index newSize, Index i);
 
     bool isIdentity(const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const;
+    EIGEN_DEVICE_FUNC
     bool isDiagonal(const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const;
 
     bool isUpperTriangular(const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const;
@@ -353,12 +359,13 @@ template<typename Derived> class MatrixBase
 
 /////////// Cholesky module ///////////
 
-    inline const LLT<PlainObject>  llt() const;
-    inline const LDLT<PlainObject> ldlt() const;
+    EIGEN_DEVICE_FUNC inline const LLT<PlainObject>  llt() const;
+    EIGEN_DEVICE_FUNC inline const LDLT<PlainObject> ldlt() const;
 
 /////////// QR module ///////////
 
     inline const HouseholderQR<PlainObject> householderQr() const;
+    EIGEN_DEVICE_FUNC
     inline const ColPivHouseholderQR<PlainObject> colPivHouseholderQr() const;
     inline const FullPivHouseholderQR<PlainObject> fullPivHouseholderQr() const;
     inline const CompleteOrthogonalDecomposition<PlainObject> completeOrthogonalDecomposition() const;
@@ -513,6 +520,7 @@ template<typename Derived> class MatrixBase
   */
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 inline Derived&
 MatrixBase<Derived>::operator*=(const EigenBase<OtherDerived> &other)
 {
@@ -527,6 +535,7 @@ MatrixBase<Derived>::operator*=(const EigenBase<OtherDerived> &other)
   */
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 inline void MatrixBase<Derived>::applyOnTheRight(const EigenBase<OtherDerived> &other)
 {
   other.derived().applyThisOnTheRight(derived());
@@ -539,6 +548,7 @@ inline void MatrixBase<Derived>::applyOnTheRight(const EigenBase<OtherDerived> &
   */
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 inline void MatrixBase<Derived>::applyOnTheLeft(const EigenBase<OtherDerived> &other)
 {
   other.derived().applyThisOnTheLeft(derived());

--- a/Eigen/src/Core/PermutationMatrix.h
+++ b/Eigen/src/Core/PermutationMatrix.h
@@ -71,6 +71,7 @@ class PermutationBase : public EigenBase<Derived>
 
     /** Copies the other permutation into *this */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator=(const PermutationBase<OtherDerived>& other)
     {
       indices() = other.indices();
@@ -79,6 +80,7 @@ class PermutationBase : public EigenBase<Derived>
 
     /** Assignment from the Transpositions \a tr */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator=(const TranspositionsBase<OtherDerived>& tr)
     {
       setIdentity(tr.size());
@@ -86,6 +88,18 @@ class PermutationBase : public EigenBase<Derived>
         applyTranspositionOnTheRight(k,tr.coeff(k));
       return derived();
     }
+
+    #ifndef EIGEN_PARSED_BY_DOXYGEN
+    /** This is a special case of the templated operator=. Its purpose is to
+      * prevent a default operator= from hiding the templated operator=.
+      */
+    EIGEN_DEVICE_FUNC
+    Derived& operator=(const PermutationBase& other)
+    {
+      indices() = other.indices();
+      return derived();
+    }
+    #endif
 
     /** \returns the number of rows */
     inline EIGEN_DEVICE_FUNC Index rows() const { return Index(indices().size()); }
@@ -116,18 +130,22 @@ class PermutationBase : public EigenBase<Derived>
     }
 
     /** const version of indices(). */
+    EIGEN_DEVICE_FUNC
     const IndicesType& indices() const { return derived().indices(); }
     /** \returns a reference to the stored array representing the permutation. */
+    EIGEN_DEVICE_FUNC
     IndicesType& indices() { return derived().indices(); }
 
     /** Resizes to given size.
       */
+    EIGEN_DEVICE_FUNC
     inline void resize(Index newSize)
     {
       indices().resize(newSize);
     }
 
     /** Sets *this to be the identity permutation matrix */
+    EIGEN_DEVICE_FUNC
     void setIdentity()
     {
       StorageIndex n = StorageIndex(size());
@@ -137,6 +155,7 @@ class PermutationBase : public EigenBase<Derived>
 
     /** Sets *this to be the identity permutation matrix of given size.
       */
+    EIGEN_DEVICE_FUNC
     void setIdentity(Index newSize)
     {
       resize(newSize);
@@ -171,10 +190,11 @@ class PermutationBase : public EigenBase<Derived>
       *
       * \sa applyTranspositionOnTheLeft(Index,Index)
       */
+    EIGEN_DEVICE_FUNC
     Derived& applyTranspositionOnTheRight(Index i, Index j)
     {
       eigen_assert(i>=0 && j>=0 && i<size() && j<size());
-      std::swap(indices().coeffRef(i), indices().coeffRef(j));
+      numext::swap(indices().coeffRef(i), indices().coeffRef(j));
       return derived();
     }
 
@@ -307,11 +327,13 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
     typedef typename Traits::StorageIndex StorageIndex;
     #endif
 
+    EIGEN_DEVICE_FUNC
     inline PermutationMatrix()
     {}
 
     /** Constructs an uninitialized permutation matrix of given size.
       */
+    EIGEN_DEVICE_FUNC
     explicit inline PermutationMatrix(Index size) : m_indices(size)
     {
       eigen_internal_assert(size <= NumTraits<StorageIndex>::highest());
@@ -319,8 +341,16 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
 
     /** Copy constructor. */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline PermutationMatrix(const PermutationBase<OtherDerived>& other)
       : m_indices(other.indices()) {}
+
+    #ifndef EIGEN_PARSED_BY_DOXYGEN
+    /** Standard copy constructor. Defined only to prevent a default copy constructor
+      * from hiding the other templated constructor */
+    EIGEN_DEVICE_FUNC
+    inline PermutationMatrix(const PermutationMatrix& other) : m_indices(other.indices()) {}
+    #endif
 
     /** Generic constructor from expression of the indices. The indices
       * array has the meaning that the permutations sends each integer i to indices[i].
@@ -330,11 +360,13 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
       * array's size.
       */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     explicit inline PermutationMatrix(const MatrixBase<Other>& indices) : m_indices(indices)
     {}
 
     /** Convert the Transpositions \a tr to a permutation matrix */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     explicit PermutationMatrix(const TranspositionsBase<Other>& tr)
       : m_indices(tr.size())
     {
@@ -343,6 +375,7 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
 
     /** Copies the other permutation into *this */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     PermutationMatrix& operator=(const PermutationBase<Other>& other)
     {
       m_indices = other.indices();
@@ -351,16 +384,31 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
 
     /** Assignment from the Transpositions \a tr */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     PermutationMatrix& operator=(const TranspositionsBase<Other>& tr)
     {
       return Base::operator=(tr.derived());
     }
 
-    /** const version of indices(). */
-    const IndicesType& indices() const { return m_indices; }
-    /** \returns a reference to the stored array representing the permutation. */
-    IndicesType& indices() { return m_indices; }
+    #ifndef EIGEN_PARSED_BY_DOXYGEN
+    /** This is a special case of the templated operator=. Its purpose is to
+      * prevent a default operator= from hiding the templated operator=.
+      */
+    EIGEN_DEVICE_FUNC
+    PermutationMatrix& operator=(const PermutationMatrix& other)
+    {
+      m_indices = other.m_indices;
+      return *this;
+    }
+    #endif
 
+    /** const version of indices(). */
+    EIGEN_DEVICE_FUNC
+    const IndicesType& indices() const { return m_indices; }
+
+    /** \returns a reference to the stored array representing the permutation. */
+    EIGEN_DEVICE_FUNC
+    IndicesType& indices() { return m_indices; }
 
     /**** multiplication helpers to hopefully get RVO ****/
 
@@ -374,7 +422,9 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
       for (StorageIndex i=0; i<end;++i)
         m_indices.coeffRef(other.derived().nestedExpression().indices().coeff(i)) = i;
     }
+
     template<typename Lhs,typename Rhs>
+    EIGEN_DEVICE_FUNC
     PermutationMatrix(internal::PermPermProduct_t, const Lhs& lhs, const Rhs& rhs)
       : m_indices(lhs.indices().size())
     {

--- a/Eigen/src/Core/PermutationMatrix.h
+++ b/Eigen/src/Core/PermutationMatrix.h
@@ -112,6 +112,7 @@ class PermutationBase : public EigenBase<Derived>
 
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename DenseDerived>
+    EIGEN_DEVICE_FUNC
     void evalTo(MatrixBase<DenseDerived>& other) const
     {
       other.setZero();
@@ -124,6 +125,7 @@ class PermutationBase : public EigenBase<Derived>
       * is inefficient to return this Matrix object by value. For efficiency, favor using
       * the Matrix constructor taking EigenBase objects.
       */
+    EIGEN_DEVICE_FUNC
     DenseMatrixType toDenseMatrix() const
     {
       return derived();
@@ -171,6 +173,7 @@ class PermutationBase : public EigenBase<Derived>
       *
       * \sa applyTranspositionOnTheRight(Index,Index)
       */
+    EIGEN_DEVICE_FUNC
     Derived& applyTranspositionOnTheLeft(Index i, Index j)
     {
       eigen_assert(i>=0 && j>=0 && i<size() && j<size());
@@ -202,12 +205,14 @@ class PermutationBase : public EigenBase<Derived>
       *
       * \note \blank \note_try_to_help_rvo
       */
+    EIGEN_DEVICE_FUNC
     inline InverseReturnType inverse() const
     { return InverseReturnType(derived()); }
     /** \returns the tranpose permutation matrix.
       *
       * \note \blank \note_try_to_help_rvo
       */
+    EIGEN_DEVICE_FUNC
     inline InverseReturnType transpose() const
     { return InverseReturnType(derived()); }
 
@@ -217,11 +222,13 @@ class PermutationBase : public EigenBase<Derived>
 #ifndef EIGEN_PARSED_BY_DOXYGEN
   protected:
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     void assignTranspose(const PermutationBase<OtherDerived>& other)
     {
       for (Index i=0; i<rows();++i) indices().coeffRef(other.indices().coeff(i)) = i;
     }
     template<typename Lhs,typename Rhs>
+    EIGEN_DEVICE_FUNC
     void assignProduct(const Lhs& lhs, const Rhs& rhs)
     {
       eigen_assert(lhs.cols() == rhs.rows());
@@ -236,6 +243,7 @@ class PermutationBase : public EigenBase<Derived>
       * \note \blank \note_try_to_help_rvo
       */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     inline PlainPermutationType operator*(const PermutationBase<Other>& other) const
     { return PlainPermutationType(internal::PermPermProduct, derived(), other.derived()); }
 
@@ -244,6 +252,7 @@ class PermutationBase : public EigenBase<Derived>
       * \note \blank \note_try_to_help_rvo
       */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     inline PlainPermutationType operator*(const InverseImpl<Other,PermutationStorage>& other) const
     { return PlainPermutationType(internal::PermPermProduct, *this, other.eval()); }
 
@@ -252,6 +261,7 @@ class PermutationBase : public EigenBase<Derived>
       * \note \blank \note_try_to_help_rvo
       */
     template<typename Other> friend
+    EIGEN_DEVICE_FUNC
     inline PlainPermutationType operator*(const InverseImpl<Other, PermutationStorage>& other, const PermutationBase& perm)
     { return PlainPermutationType(internal::PermPermProduct, other.eval(), perm); }
     
@@ -259,6 +269,7 @@ class PermutationBase : public EigenBase<Derived>
       *
       * This function is O(\c n) procedure allocating a buffer of \c n booleans.
       */
+    EIGEN_DEVICE_FUNC
     Index determinant() const
     {
       Index res = 1;
@@ -414,6 +425,7 @@ class PermutationMatrix : public PermutationBase<PermutationMatrix<SizeAtCompile
 
 #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     PermutationMatrix(const InverseImpl<Other,PermutationStorage>& other)
       : m_indices(other.derived().nestedExpression().size())
     {
@@ -463,21 +475,25 @@ class Map<PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime, _StorageInd
     typedef typename IndicesType::Scalar StorageIndex;
     #endif
 
+    EIGEN_DEVICE_FUNC
     inline Map(const StorageIndex* indicesPtr)
       : m_indices(indicesPtr)
     {}
 
+    EIGEN_DEVICE_FUNC
     inline Map(const StorageIndex* indicesPtr, Index size)
       : m_indices(indicesPtr,size)
     {}
 
     /** Copies the other permutation into *this */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     Map& operator=(const PermutationBase<Other>& other)
     { return Base::operator=(other.derived()); }
 
     /** Assignment from the Transpositions \a tr */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     Map& operator=(const TranspositionsBase<Other>& tr)
     { return Base::operator=(tr.derived()); }
 
@@ -485,6 +501,7 @@ class Map<PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime, _StorageInd
     /** This is a special case of the templated operator=. Its purpose is to
       * prevent a default operator= from hiding the templated operator=.
       */
+    EIGEN_DEVICE_FUNC
     Map& operator=(const Map& other)
     {
       m_indices = other.m_indices;
@@ -493,8 +510,10 @@ class Map<PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime, _StorageInd
     #endif
 
     /** const version of indices(). */
+    EIGEN_DEVICE_FUNC
     const IndicesType& indices() const { return m_indices; }
     /** \returns a reference to the stored array representing the permutation. */
+    EIGEN_DEVICE_FUNC
     IndicesType& indices() { return m_indices; }
 
   protected:
@@ -543,12 +562,15 @@ class PermutationWrapper : public PermutationBase<PermutationWrapper<_IndicesTyp
     typedef typename Traits::IndicesType IndicesType;
     #endif
 
+    EIGEN_DEVICE_FUNC
     inline PermutationWrapper(const IndicesType& indices)
       : m_indices(indices)
     {}
 
     /** const version of indices(). */
+    EIGEN_DEVICE_FUNC
     const typename internal::remove_all<typename IndicesType::Nested>::type&
+    EIGEN_DEVICE_FUNC
     indices() const { return m_indices; }
 
   protected:
@@ -589,6 +611,7 @@ class InverseImpl<PermutationType, PermutationStorage>
     typedef typename PermutationType::PlainPermutationType PlainPermutationType;
     typedef internal::traits<PermutationType> PermTraits;
   protected:
+    EIGEN_DEVICE_FUNC
     InverseImpl() {}
   public:
     typedef Inverse<PermutationType> InverseType;
@@ -606,6 +629,7 @@ class InverseImpl<PermutationType, PermutationStorage>
 
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename DenseDerived>
+    EIGEN_DEVICE_FUNC
     void evalTo(MatrixBase<DenseDerived>& other) const
     {
       other.setZero();
@@ -615,13 +639,16 @@ class InverseImpl<PermutationType, PermutationStorage>
     #endif
 
     /** \return the equivalent permutation matrix */
+    EIGEN_DEVICE_FUNC
     PlainPermutationType eval() const { return derived(); }
 
+    EIGEN_DEVICE_FUNC
     DenseMatrixType toDenseMatrix() const { return derived(); }
 
     /** \returns the matrix with the inverse permutation applied to the columns.
       */
     template<typename OtherDerived> friend
+    EIGEN_DEVICE_FUNC
     const Product<OtherDerived, InverseType, AliasFreeProduct>
     operator*(const MatrixBase<OtherDerived>& matrix, const InverseType& trPerm)
     {
@@ -631,6 +658,7 @@ class InverseImpl<PermutationType, PermutationStorage>
     /** \returns the matrix with the inverse permutation applied to the rows.
       */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     const Product<InverseType, OtherDerived, AliasFreeProduct>
     operator*(const MatrixBase<OtherDerived>& matrix) const
     {
@@ -639,6 +667,7 @@ class InverseImpl<PermutationType, PermutationStorage>
 };
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 const PermutationWrapper<const Derived> MatrixBase<Derived>::asPermutation() const
 {
   return derived();

--- a/Eigen/src/Core/PlainObjectBase.h
+++ b/Eigen/src/Core/PlainObjectBase.h
@@ -655,10 +655,12 @@ class PlainObjectBase : public internal::dense_xpr_base<Derived>::type
     { return MapType(data); }
     static inline ConstMapType Map(const Scalar* data, Index size)
     { return ConstMapType(data, size); }
+    EIGEN_DEVICE_FUNC
     static inline MapType Map(Scalar* data, Index size)
     { return MapType(data, size); }
     static inline ConstMapType Map(const Scalar* data, Index rows, Index cols)
     { return ConstMapType(data, rows, cols); }
+    EIGEN_DEVICE_FUNC
     static inline MapType Map(Scalar* data, Index rows, Index cols)
     { return MapType(data, rows, cols); }
 
@@ -993,6 +995,7 @@ struct conservative_resize_like_impl
   #else
   static const bool IsRelocatable = !NumTraits<typename Derived::Scalar>::RequireInitialization;
   #endif
+  EIGEN_DEVICE_FUNC
   static void run(DenseBase<Derived>& _this, Index rows, Index cols)
   {
     if (_this.rows() == rows && _this.cols() == cols) return;
@@ -1016,6 +1019,7 @@ struct conservative_resize_like_impl
     }
   }
 
+  EIGEN_DEVICE_FUNC
   static void run(DenseBase<Derived>& _this, const DenseBase<OtherDerived>& other)
   {
     if (_this.rows() == other.rows() && _this.cols() == other.cols()) return;

--- a/Eigen/src/Core/ProductEvaluators.h
+++ b/Eigen/src/Core/ProductEvaluators.h
@@ -808,6 +808,7 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,SelfAdjointShape,ProductTag>
   typedef typename Product<Lhs,Rhs>::Scalar Scalar;
   
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void scaleAndAddTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
   {
     selfadjoint_product_impl<Lhs,0,Lhs::IsVectorAtCompileTime,typename Rhs::MatrixType,Rhs::Mode,false>::run(dst, lhs, rhs.nestedExpression(), alpha);

--- a/Eigen/src/Core/ProductEvaluators.h
+++ b/Eigen/src/Core/ProductEvaluators.h
@@ -759,6 +759,7 @@ struct generic_product_impl<Lhs,Rhs,TriangularShape,DenseShape,ProductTag>
   typedef typename Product<Lhs,Rhs>::Scalar Scalar;
   
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void scaleAndAddTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
   {
     triangular_product_impl<Lhs::Mode,true,typename Lhs::MatrixType,false,Rhs, Rhs::ColsAtCompileTime==1>
@@ -773,6 +774,7 @@ struct generic_product_impl<Lhs,Rhs,DenseShape,TriangularShape,ProductTag>
   typedef typename Product<Lhs,Rhs>::Scalar Scalar;
   
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void scaleAndAddTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, const Scalar& alpha)
   {
     triangular_product_impl<Rhs::Mode,false,Lhs,Lhs::RowsAtCompileTime==1, typename Rhs::MatrixType, false>::run(dst, lhs, rhs.nestedExpression(), alpha);
@@ -872,6 +874,7 @@ public:
   
 protected:
   template<int LoadMode,typename PacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketType packet_impl(Index row, Index col, Index id, internal::true_type) const
   {
     return internal::pmul(m_matImpl.template packet<LoadMode,PacketType>(row, col),
@@ -879,6 +882,7 @@ protected:
   }
   
   template<int LoadMode,typename PacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketType packet_impl(Index row, Index col, Index id, internal::false_type) const
   {
     enum {
@@ -923,6 +927,7 @@ struct product_evaluator<Product<Lhs, Rhs, ProductKind>, ProductTag, DiagonalSha
   
 #ifndef EIGEN_GPUCC
   template<int LoadMode,typename PacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketType packet(Index row, Index col) const
   {
     // FIXME: NVCC used to complain about the template keyword, but we have to check whether this is still the case.
@@ -932,6 +937,7 @@ struct product_evaluator<Product<Lhs, Rhs, ProductKind>, ProductTag, DiagonalSha
   }
   
   template<int LoadMode,typename PacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketType packet(Index idx) const
   {
     return packet<LoadMode,PacketType>(int(StorageOrder)==ColMajor?idx:0,int(StorageOrder)==ColMajor?0:idx);
@@ -967,6 +973,7 @@ struct product_evaluator<Product<Lhs, Rhs, ProductKind>, ProductTag, DenseShape,
   
 #ifndef EIGEN_GPUCC
   template<int LoadMode,typename PacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketType packet(Index row, Index col) const
   {
     return this->template packet_impl<LoadMode,PacketType>(row,col, col,
@@ -974,6 +981,7 @@ struct product_evaluator<Product<Lhs, Rhs, ProductKind>, ProductTag, DenseShape,
   }
   
   template<int LoadMode,typename PacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE PacketType packet(Index idx) const
   {
     return packet<LoadMode,PacketType>(int(StorageOrder)==ColMajor?idx:0,int(StorageOrder)==ColMajor?0:idx);

--- a/Eigen/src/Core/ProductEvaluators.h
+++ b/Eigen/src/Core/ProductEvaluators.h
@@ -1008,6 +1008,7 @@ struct permutation_matrix_product<ExpressionType, Side, Transposed, DenseShape>
     typedef typename remove_all<MatrixType>::type MatrixTypeCleaned;
 
     template<typename Dest, typename PermutationType>
+    EIGEN_DEVICE_FUNC
     static inline void run(Dest& dst, const PermutationType& perm, const ExpressionType& xpr)
     {
       MatrixType mat(xpr);

--- a/Eigen/src/Core/SelfAdjointView.h
+++ b/Eigen/src/Core/SelfAdjointView.h
@@ -247,8 +247,8 @@ template<typename _MatrixType, unsigned int UpLo> class SelfAdjointView
 
 /////////// Cholesky module ///////////
 
-    const LLT<PlainObject, UpLo> llt() const;
-    const LDLT<PlainObject, UpLo> ldlt() const;
+    EIGEN_DEVICE_FUNC const LLT<PlainObject, UpLo> llt() const;
+    EIGEN_DEVICE_FUNC const LDLT<PlainObject, UpLo> ldlt() const;
 
 /////////// Eigenvalue module ///////////
 

--- a/Eigen/src/Core/Solve.h
+++ b/Eigen/src/Core/Solve.h
@@ -137,6 +137,7 @@ template<typename DstXprType, typename DecType, typename RhsType, typename Scala
 struct Assignment<DstXprType, Solve<DecType,RhsType>, internal::assign_op<Scalar,Scalar>, Dense2Dense>
 {
   typedef Solve<DecType,RhsType> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
   {
     Index dstRows = src.rows();

--- a/Eigen/src/Core/Solve.h
+++ b/Eigen/src/Core/Solve.h
@@ -154,7 +154,7 @@ template<typename DstXprType, typename DecType, typename RhsType, typename Scala
 struct Assignment<DstXprType, Solve<Transpose<const DecType>,RhsType>, internal::assign_op<Scalar,Scalar>, Dense2Dense>
 {
   typedef Solve<Transpose<const DecType>,RhsType> SrcXprType;
-  static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
+  EIGEN_DEVICE_FUNC static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
   {
     Index dstRows = src.rows();
     Index dstCols = src.cols();
@@ -171,7 +171,7 @@ struct Assignment<DstXprType, Solve<CwiseUnaryOp<internal::scalar_conjugate_op<t
                   internal::assign_op<Scalar,Scalar>, Dense2Dense>
 {
   typedef Solve<CwiseUnaryOp<internal::scalar_conjugate_op<typename DecType::Scalar>, const Transpose<const DecType> >,RhsType> SrcXprType;
-  static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
+  EIGEN_DEVICE_FUNC static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
   {
     Index dstRows = src.rows();
     Index dstCols = src.cols();

--- a/Eigen/src/Core/SolverBase.h
+++ b/Eigen/src/Core/SolverBase.h
@@ -91,9 +91,11 @@ class SolverBase : public EigenBase<Derived>
     };
 
     /** Default constructor */
+    EIGEN_DEVICE_FUNC
     SolverBase()
     {}
 
+    EIGEN_DEVICE_FUNC
     ~SolverBase()
     {}
 

--- a/Eigen/src/Core/Transpositions.h
+++ b/Eigen/src/Core/Transpositions.h
@@ -44,14 +44,19 @@ class TranspositionsBase
     /** Direct access to the underlying index vector */
     inline const StorageIndex& coeff(Index i) const { return indices().coeff(i); }
     /** Direct access to the underlying index vector */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex& coeffRef(Index i) { return indices().coeffRef(i); }
     /** Direct access to the underlying index vector */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex& operator()(Index i) const { return indices()(i); }
     /** Direct access to the underlying index vector */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex& operator()(Index i) { return indices()(i); }
     /** Direct access to the underlying index vector */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex& operator[](Index i) const { return indices()(i); }
     /** Direct access to the underlying index vector */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex& operator[](Index i) { return indices()(i); }
 
     /** const version of indices(). */
@@ -60,12 +65,14 @@ class TranspositionsBase
     IndicesType& indices() { return derived().indices(); }
 
     /** Resizes to given size. */
+    EIGEN_DEVICE_FUNC
     inline void resize(Index newSize)
     {
       indices().resize(newSize);
     }
 
     /** Sets \c *this to represents an identity transformation */
+    EIGEN_DEVICE_FUNC
     void setIdentity()
     {
       for(StorageIndex i = 0; i < indices().size(); ++i)
@@ -153,32 +160,50 @@ class Transpositions : public TranspositionsBase<Transpositions<SizeAtCompileTim
     typedef typename Traits::IndicesType IndicesType;
     typedef typename IndicesType::Scalar StorageIndex;
 
+    EIGEN_DEVICE_FUNC
     inline Transpositions() {}
 
     /** Copy constructor. */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline Transpositions(const TranspositionsBase<OtherDerived>& other)
       : m_indices(other.indices()) {}
 
     /** Generic constructor from expression of the transposition indices. */
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     explicit inline Transpositions(const MatrixBase<Other>& indices) : m_indices(indices)
     {}
 
     /** Copies the \a other transpositions into \c *this */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Transpositions& operator=(const TranspositionsBase<OtherDerived>& other)
     {
       return Base::operator=(other);
     }
 
+    #ifndef EIGEN_PARSED_BY_DOXYGEN
+    /** This is a special case of the templated operator=. Its purpose is to
+      * prevent a default operator= from hiding the templated operator=.
+      */
+    EIGEN_DEVICE_FUNC
+    Transpositions& operator=(const Transpositions& other)
+    {
+      m_indices = other.m_indices;
+      return *this;
+    }
+    #endif
+
     /** Constructs an uninitialized permutation matrix of given size.
       */
+    EIGEN_DEVICE_FUNC
     inline Transpositions(Index size) : m_indices(size)
     {}
 
     /** const version of indices(). */
     const IndicesType& indices() const { return m_indices; }
+
     /** \returns a reference to the stored array representing the transpositions. */
     IndicesType& indices() { return m_indices; }
 

--- a/Eigen/src/Core/Transpositions.h
+++ b/Eigen/src/Core/Transpositions.h
@@ -28,6 +28,7 @@ class TranspositionsBase
 
     /** Copies the \a other transpositions into \c *this */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator=(const TranspositionsBase<OtherDerived>& other)
     {
       indices() = other.indices();
@@ -101,10 +102,12 @@ class TranspositionsBase
     */
 
     /** \returns the inverse transformation */
+    EIGEN_DEVICE_FUNC
     inline Transpose<TranspositionsBase> inverse() const
     { return Transpose<TranspositionsBase>(derived()); }
 
     /** \returns the tranpose transformation */
+    EIGEN_DEVICE_FUNC
     inline Transpose<TranspositionsBase> transpose() const
     { return Transpose<TranspositionsBase>(derived()); }
 
@@ -235,16 +238,19 @@ class Map<Transpositions<SizeAtCompileTime,MaxSizeAtCompileTime,_StorageIndex>,P
     typedef typename Traits::IndicesType IndicesType;
     typedef typename IndicesType::Scalar StorageIndex;
 
+    EIGEN_DEVICE_FUNC
     explicit inline Map(const StorageIndex* indicesPtr)
       : m_indices(indicesPtr)
     {}
 
+    EIGEN_DEVICE_FUNC
     inline Map(const StorageIndex* indicesPtr, Index size)
       : m_indices(indicesPtr,size)
     {}
 
     /** Copies the \a other transpositions into \c *this */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Map& operator=(const TranspositionsBase<OtherDerived>& other)
     {
       return Base::operator=(other);
@@ -292,12 +298,14 @@ class TranspositionsWrapper
     typedef typename Traits::IndicesType IndicesType;
     typedef typename IndicesType::Scalar StorageIndex;
 
+    EIGEN_DEVICE_FUNC
     explicit inline TranspositionsWrapper(IndicesType& indices)
       : m_indices(indices)
     {}
 
     /** Copies the \a other transpositions into \c *this */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     TranspositionsWrapper& operator=(const TranspositionsBase<OtherDerived>& other)
     {
       return Base::operator=(other);
@@ -358,6 +366,7 @@ class Transpose<TranspositionsBase<TranspositionsDerived> >
     typedef typename TranspositionType::IndicesType IndicesType;
   public:
 
+    EIGEN_DEVICE_FUNC
     explicit Transpose(const TranspositionType& t) : m_transpositions(t) {}
 
     Index size() const { return m_transpositions.size(); }
@@ -367,6 +376,7 @@ class Transpose<TranspositionsBase<TranspositionsDerived> >
     /** \returns the \a matrix with the inverse transpositions applied to the columns.
       */
     template<typename OtherDerived> friend
+    EIGEN_DEVICE_FUNC
     const Product<OtherDerived, Transpose, AliasFreeProduct>
     operator*(const MatrixBase<OtherDerived>& matrix, const Transpose& trt)
     {
@@ -376,6 +386,7 @@ class Transpose<TranspositionsBase<TranspositionsDerived> >
     /** \returns the \a matrix with the inverse transpositions applied to the rows.
       */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     const Product<Transpose, OtherDerived, AliasFreeProduct>
     operator*(const MatrixBase<OtherDerived>& matrix) const
     {

--- a/Eigen/src/Core/TriangularMatrix.h
+++ b/Eigen/src/Core/TriangularMatrix.h
@@ -961,6 +961,8 @@ template< typename DstXprType, typename Lhs, typename Rhs, typename Scalar>
 struct Assignment<DstXprType, Product<Lhs,Rhs,DefaultProduct>, internal::assign_op<Scalar,typename Product<Lhs,Rhs,DefaultProduct>::Scalar>, Dense2Triangular>
 {
   typedef Product<Lhs,Rhs,DefaultProduct> SrcXprType;
+
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,typename SrcXprType::Scalar> &)
   {
     Index dstRows = src.rows();

--- a/Eigen/src/Core/TriangularMatrix.h
+++ b/Eigen/src/Core/TriangularMatrix.h
@@ -979,6 +979,7 @@ template< typename DstXprType, typename Lhs, typename Rhs, typename Scalar>
 struct Assignment<DstXprType, Product<Lhs,Rhs,DefaultProduct>, internal::add_assign_op<Scalar,typename Product<Lhs,Rhs,DefaultProduct>::Scalar>, Dense2Triangular>
 {
   typedef Product<Lhs,Rhs,DefaultProduct> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::add_assign_op<Scalar,typename SrcXprType::Scalar> &)
   {
     dst._assignProduct(src, 1, 1);
@@ -990,6 +991,7 @@ template< typename DstXprType, typename Lhs, typename Rhs, typename Scalar>
 struct Assignment<DstXprType, Product<Lhs,Rhs,DefaultProduct>, internal::sub_assign_op<Scalar,typename Product<Lhs,Rhs,DefaultProduct>::Scalar>, Dense2Triangular>
 {
   typedef Product<Lhs,Rhs,DefaultProduct> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::sub_assign_op<Scalar,typename SrcXprType::Scalar> &)
   {
     dst._assignProduct(src, -1, 1);

--- a/Eigen/src/Core/functors/BinaryFunctors.h
+++ b/Eigen/src/Core/functors/BinaryFunctors.h
@@ -35,6 +35,7 @@ struct scalar_sum_op : binary_op_base<LhsScalar,RhsScalar>
 #ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
   EIGEN_EMPTY_STRUCT_CTOR(scalar_sum_op)
 #else
+  EIGEN_DEVICE_FUNC
   scalar_sum_op() {
     EIGEN_SCALAR_BINARY_OP_PLUGIN
   }
@@ -73,6 +74,7 @@ struct scalar_product_op  : binary_op_base<LhsScalar,RhsScalar>
 #ifndef EIGEN_SCALAR_BINARY_OP_PLUGIN
   EIGEN_EMPTY_STRUCT_CTOR(scalar_product_op)
 #else
+  EIGEN_DEVICE_FUNC
   scalar_product_op() {
     EIGEN_SCALAR_BINARY_OP_PLUGIN
   }

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -1454,6 +1454,7 @@ struct lhs_process_one_packet
 {
   typedef typename GEBPTraits::RhsPacketx4 RhsPacketx4;
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void peeled_kc_onestep(Index K, const LhsScalar* blA, const RhsScalar* blB, GEBPTraits traits, LhsPacket *A0, RhsPacketx4 *rhs_panel, RhsPacket *T0, AccPacket *C0, AccPacket *C1, AccPacket *C2, AccPacket *C3)
   {
     EIGEN_ASM_COMMENT("begin step of gebp micro kernel 1X4");
@@ -1470,6 +1471,7 @@ struct lhs_process_one_packet
     EIGEN_ASM_COMMENT("end step of gebp micro kernel 1X4");
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void operator()(
     const DataMapper& res, const LhsScalar* blockA, const RhsScalar* blockB, ResScalar alpha,
     Index peelStart, Index peelEnd, Index strideA, Index strideB, Index offsetA, Index offsetB,

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -97,19 +97,21 @@ inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff
   #ifdef EIGEN_CUDA_ARCH
   if (action==GetAction)
   {
-    // assume some sensible numbers
+    #if EIGEN_CUDA_ARCH >= 700
+    // Volta, Turing, or newer
+    //   - the L1 cache is configurable at runtime, with a minimum of 32 KB/SM
+    //   - the L2 cache depends on the actual card, with a minimum of 64 KB/SM
     *l1 =   32 * 1024;
-    *l2 = 1024 * 1024;
+    *l2 =   64 * 1024;
     *l3 =           0;
-    // query the L2 cache size
-    int currentDevice;
-    int l2CacheSize;
-    cudaGetDevice(&currentDevice);
-    cudaDeviceGetAttribute(&l2CacheSize, cudaDevAttrL2CacheSize, currentDevice);
-    if (l2CacheSize)
-    {
-      *l2 = l2CacheSize;
-    }
+    #else
+    // Kepler, Maxwell, Pascal
+    //   - the L1 cache is configurable at runtime, with a minimum of 16 KB/SM
+    //   - the L2 cache depends on the actual card, with a minimum of 64 KB/SM
+    *l1 =   16 * 1024;
+    *l2 =   64 * 1024;
+    *l3 =           0;
+    #endif
   }
   else
   {

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -2503,11 +2503,11 @@ template<typename Scalar, typename Index, typename DataMapper, int Pack1, int Pa
 struct gemm_pack_lhs<Scalar, Index, DataMapper, Pack1, Pack2, Packet, RowMajor, Conjugate, PanelMode>
 {
   typedef typename DataMapper::LinearMapper LinearMapper;
-  EIGEN_DONT_INLINE void operator()(Scalar* blockA, const DataMapper& lhs, Index depth, Index rows, Index stride=0, Index offset=0);
+  EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void operator()(Scalar* blockA, const DataMapper& lhs, Index depth, Index rows, Index stride=0, Index offset=0);
 };
 
 template<typename Scalar, typename Index, typename DataMapper, int Pack1, int Pack2, typename Packet, bool Conjugate, bool PanelMode>
-EIGEN_DONT_INLINE void gemm_pack_lhs<Scalar, Index, DataMapper, Pack1, Pack2, Packet, RowMajor, Conjugate, PanelMode>
+EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void gemm_pack_lhs<Scalar, Index, DataMapper, Pack1, Pack2, Packet, RowMajor, Conjugate, PanelMode>
   ::operator()(Scalar* blockA, const DataMapper& lhs, Index depth, Index rows, Index stride, Index offset)
 {
   typedef typename unpacket_traits<Packet>::half HalfPacket;
@@ -2766,8 +2766,8 @@ struct gemm_pack_rhs<Scalar, Index, DataMapper, nr, RowMajor, Conjugate, PanelMo
   typedef typename DataMapper::LinearMapper LinearMapper;
   enum { PacketSize = packet_traits<Scalar>::size,
          HalfPacketSize = unpacket_traits<HalfPacket>::size,
-		 QuarterPacketSize = unpacket_traits<QuarterPacket>::size};
-  EIGEN_DONT_INLINE void operator()(Scalar* blockB, const DataMapper& rhs, Index depth, Index cols, Index stride=0, Index offset=0)
+         QuarterPacketSize = unpacket_traits<QuarterPacket>::size};
+  EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void operator()(Scalar* blockB, const DataMapper& rhs, Index depth, Index cols, Index stride=0, Index offset=0)
   {
     EIGEN_ASM_COMMENT("EIGEN PRODUCT PACK RHS ROWMAJOR");
     EIGEN_UNUSED_VARIABLE(stride);

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -72,7 +72,14 @@ const std::ptrdiff_t defaultL3CacheSize = EIGEN_SET_DEFAULT_L3_CACHE_SIZE(512*10
 struct CacheSizes {
   CacheSizes(): m_l1(-1),m_l2(-1),m_l3(-1) {
     int l1CacheSize, l2CacheSize, l3CacheSize;
+
+#if !defined(EIGEN_CUDA_ARCH)
     queryCacheSizes(l1CacheSize, l2CacheSize, l3CacheSize);
+#else
+    l1CacheSize = defaultL1CacheSize;
+    l2CacheSize = 1572864;
+    l3CacheSize = defaultL3CacheSize;
+#endif
     m_l1 = manage_caching_sizes_helper(l1CacheSize, defaultL1CacheSize);
     m_l2 = manage_caching_sizes_helper(l2CacheSize, defaultL2CacheSize);
     m_l3 = manage_caching_sizes_helper(l3CacheSize, defaultL3CacheSize);
@@ -1078,6 +1085,7 @@ public:
     dest = pset1<RhsPacketType>(*b);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, RhsPacketx4& dest) const
   {
     pbroadcast4(b, dest.B_0, dest.B1, dest.B2, dest.B3);

--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -26,6 +26,7 @@ class gebp_traits;
 
 
 /** \internal \returns b if a<=0, and returns a otherwise. */
+EIGEN_DEVICE_FUNC
 inline std::ptrdiff_t manage_caching_sizes_helper(std::ptrdiff_t a, std::ptrdiff_t b)
 {
   return a<=0 ? b : a;
@@ -83,8 +84,31 @@ struct CacheSizes {
 };
 
 /** \internal */
+EIGEN_DEVICE_FUNC
 inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff_t* l2, std::ptrdiff_t* l3)
 {
+  #ifdef EIGEN_CUDA_ARCH
+  if (action==GetAction)
+  {
+    // assume some sensible numbers
+    *l1 =   32 * 1024;
+    *l2 = 1024 * 1024;
+    *l3 =           0;
+    // query the L2 cache size
+    int currentDevice;
+    int l2CacheSize;
+    cudaGetDevice(&currentDevice);
+    cudaDeviceGetAttribute(&l2CacheSize, cudaDevAttrL2CacheSize, currentDevice);
+    if (l2CacheSize)
+    {
+      *l2 = l2CacheSize;
+    }
+  }
+  else
+  {
+    eigen_internal_assert(false);
+  }
+  #else // EIGEN_CUDA_ARCH
   static CacheSizes m_cacheSizes;
 
   if(action==SetAction)
@@ -106,6 +130,7 @@ inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff
   {
     eigen_internal_assert(false);
   }
+  #endif
 }
 
 /* Helper for computeProductBlockingSizes.
@@ -121,6 +146,7 @@ inline void manage_caching_sizes(Action action, std::ptrdiff_t* l1, std::ptrdiff
  * \sa setCpuCacheSizes */
 
 template<typename LhsScalar, typename RhsScalar, int KcFactor, typename Index>
+EIGEN_DEVICE_FUNC
 void evaluateProductBlockingSizesHeuristic(Index& k, Index& m, Index& n, Index num_threads = 1)
 {
   typedef gebp_traits<LhsScalar,RhsScalar> Traits;
@@ -302,6 +328,7 @@ void evaluateProductBlockingSizesHeuristic(Index& k, Index& m, Index& n, Index n
 }
 
 template <typename Index>
+EIGEN_DEVICE_FUNC
 inline bool useSpecificBlockingSizes(Index& k, Index& m, Index& n)
 {
 #ifdef EIGEN_TEST_SPECIFIC_BLOCKING_SIZES
@@ -336,6 +363,7 @@ inline bool useSpecificBlockingSizes(Index& k, Index& m, Index& n)
   * \sa setCpuCacheSizes */
 
 template<typename LhsScalar, typename RhsScalar, int KcFactor, typename Index>
+EIGEN_DEVICE_FUNC
 void computeProductBlockingSizes(Index& k, Index& m, Index& n, Index num_threads = 1)
 {
   if (!useSpecificBlockingSizes(k, m, n)) {
@@ -344,6 +372,7 @@ void computeProductBlockingSizes(Index& k, Index& m, Index& n, Index num_threads
 }
 
 template<typename LhsScalar, typename RhsScalar, typename Index>
+EIGEN_DEVICE_FUNC
 inline void computeProductBlockingSizes(Index& k, Index& m, Index& n, Index num_threads = 1)
 {
   computeProductBlockingSizes<LhsScalar,RhsScalar,1,Index>(k, m, n, num_threads);
@@ -356,6 +385,7 @@ inline void computeProductBlockingSizes(Index& k, Index& m, Index& n, Index num_
   // FIXME (a bit overkill maybe ?)
 
   template<typename CJ, typename A, typename B, typename C, typename T> struct gebp_madd_selector {
+    EIGEN_DEVICE_FUNC
     EIGEN_ALWAYS_INLINE static void run(const CJ& cj, A& a, B& b, C& c, T& /*t*/)
     {
       c = cj.pmadd(a,b,c);
@@ -363,6 +393,7 @@ inline void computeProductBlockingSizes(Index& k, Index& m, Index& n, Index num_
   };
 
   template<typename CJ, typename T> struct gebp_madd_selector<CJ,T,T,T,T> {
+    EIGEN_DEVICE_FUNC
     EIGEN_ALWAYS_INLINE static void run(const CJ& cj, T& a, T& b, T& c, T& t)
     {
       t = b; t = cj.pmul(a,t); c = padd(c,t);
@@ -370,6 +401,7 @@ inline void computeProductBlockingSizes(Index& k, Index& m, Index& n, Index num_
   };
 
   template<typename CJ, typename A, typename B, typename C, typename T>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void gebp_madd(const CJ& cj, A& a, B& b, C& c, T& t)
   {
     gebp_madd_selector<CJ,A,B,C,T>::run(cj,a,b,c,t);
@@ -495,50 +527,59 @@ public:
   typedef QuadPacket<RhsPacket> RhsPacketx4;
   typedef ResPacket AccPacket;
   
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void initAcc(AccPacket& p)
   {
     p = pset1<ResPacket>(ResScalar(0));
   }
 
   template<typename RhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, RhsPacketType& dest) const
   {
     dest = pset1<RhsPacketType>(*b);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, RhsPacketx4& dest) const
   {
     pbroadcast4(b, dest.B_0, dest.B1, dest.B2, dest.B3);
   }
 
   template<typename RhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar* b, RhsPacketType& dest) const
   {
     loadRhs(b, dest);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar*, RhsPacketx4&) const
   {
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad(const RhsScalar* b, RhsPacket& dest) const
   {
     dest = ploadquad<RhsPacket>(b);
   }
 
   template<typename LhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhs(const LhsScalar* a, LhsPacketType& dest) const
   {
     dest = pload<LhsPacketType>(a);
   }
 
   template<typename LhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhsUnaligned(const LhsScalar* a, LhsPacketType& dest) const
   {
     dest = ploadu<LhsPacketType>(a);
   }
 
   template<typename LhsPacketType, typename RhsPacketType, typename AccPacketType, typename LaneIdType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd(const LhsPacketType& a, const RhsPacketType& b, AccPacketType& c, RhsPacketType& tmp, const LaneIdType&) const
   {
     conj_helper<LhsPacketType,RhsPacketType,ConjLhs,ConjRhs> cj;
@@ -555,17 +596,20 @@ public:
   }
 
   template<typename LhsPacketType, typename AccPacketType, typename LaneIdType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd(const LhsPacketType& a, const RhsPacketx4& b, AccPacketType& c, RhsPacket& tmp, const LaneIdType& lane) const
   {
     madd(a, b.get(lane), c, tmp, lane);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void acc(const AccPacket& c, const ResPacket& alpha, ResPacket& r) const
   {
     r = pmadd(c,alpha,r);
   }
   
   template<typename ResPacketHalf>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void acc(const ResPacketHalf& c, const ResPacketHalf& alpha, ResPacketHalf& r) const
   {
     r = pmadd(c,alpha,r);
@@ -615,12 +659,14 @@ public:
 
   typedef ResPacket AccPacket;
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void initAcc(AccPacket& p)
   {
     p = pset1<ResPacket>(ResScalar(0));
   }
 
   template<typename RhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, RhsPacketType& dest) const
   {
     dest = pset1<RhsPacketType>(*b);
@@ -640,11 +686,13 @@ public:
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar*, RhsPacketx4&) const
   {}
   
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad(const RhsScalar* b, RhsPacket& dest) const
   {
     loadRhsQuad_impl(b,dest, typename conditional<RhsPacketSize==16,true_type,false_type>::type());
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad_impl(const RhsScalar* b, RhsPacket& dest, const true_type&) const
   {
     // FIXME we can do better!
@@ -653,30 +701,35 @@ public:
     dest = ploadquad<RhsPacket>(tmp);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad_impl(const RhsScalar* b, RhsPacket& dest, const false_type&) const
   {
     eigen_internal_assert(RhsPacketSize<=8);
     dest = pset1<RhsPacket>(*b);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhs(const LhsScalar* a, LhsPacket& dest) const
   {
     dest = pload<LhsPacket>(a);
   }
 
   template<typename LhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhsUnaligned(const LhsScalar* a, LhsPacketType& dest) const
   {
     dest = ploadu<LhsPacketType>(a);
   }
 
   template <typename LhsPacketType, typename RhsPacketType, typename AccPacketType, typename LaneIdType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd(const LhsPacketType& a, const RhsPacketType& b, AccPacketType& c, RhsPacketType& tmp, const LaneIdType&) const
   {
     madd_impl(a, b, c, tmp, typename conditional<Vectorizable,true_type,false_type>::type());
   }
 
   template <typename LhsPacketType, typename RhsPacketType, typename AccPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd_impl(const LhsPacketType& a, const RhsPacketType& b, AccPacketType& c, RhsPacketType& tmp, const true_type&) const
   {
 #ifdef EIGEN_HAS_SINGLE_INSTRUCTION_MADD
@@ -687,6 +740,7 @@ public:
 #endif
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd_impl(const LhsScalar& a, const RhsScalar& b, ResScalar& c, RhsScalar& /*tmp*/, const false_type&) const
   {
     c += a * b;
@@ -699,6 +753,7 @@ public:
   }
 
   template <typename ResPacketType, typename AccPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void acc(const AccPacketType& c, const ResPacketType& alpha, ResPacketType& r) const
   {
     conj_helper<ResPacketType,ResPacketType,ConjLhs,false> cj;
@@ -828,8 +883,10 @@ public:
   // this actualy holds 8 packets!
   typedef QuadPacket<RhsPacket> RhsPacketx4;
   
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void initAcc(Scalar& p) { p = Scalar(0); }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void initAcc(DoublePacketType& p)
   {
     p.first   = pset1<RealPacket>(RealScalar(0));
@@ -837,6 +894,7 @@ public:
   }
 
   // Scalar path
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, ScalarPacket& dest) const
   {
     dest = pset1<ScalarPacket>(*b);
@@ -844,12 +902,14 @@ public:
 
   // Vectorized path
   template<typename RealPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, DoublePacket<RealPacketType>& dest) const
   {
     dest.first  = pset1<RealPacketType>(numext::real(*b));
     dest.second = pset1<RealPacketType>(numext::imag(*b));
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, RhsPacketx4& dest) const
   {
     loadRhs(b, dest.B_0);
@@ -859,6 +919,7 @@ public:
   }
 
   // Scalar path
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar* b, ScalarPacket& dest) const
   {
     loadRhs(b, dest);
@@ -866,6 +927,7 @@ public:
 
   // Vectorized path
   template<typename RealPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar* b, DoublePacket<RealPacketType>& dest) const
   {
     loadRhs(b, dest);
@@ -873,28 +935,33 @@ public:
 
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar*, RhsPacketx4&) const {}
   
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad(const RhsScalar* b, ResPacket& dest) const
   {
     loadRhs(b,dest);
   }
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad(const RhsScalar* b, DoublePacketType& dest) const
   {
     loadQuadToDoublePacket(b,dest);
   }
 
   // nothing special here
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhs(const LhsScalar* a, LhsPacket& dest) const
   {
     dest = pload<LhsPacket>((const typename unpacket_traits<LhsPacket>::type*)(a));
   }
 
   template<typename LhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhsUnaligned(const LhsScalar* a, LhsPacketType& dest) const
   {
     dest = ploadu<LhsPacketType>((const typename unpacket_traits<LhsPacketType>::type*)(a));
   }
 
   template<typename LhsPacketType, typename RhsPacketType, typename ResPacketType, typename TmpType, typename LaneIdType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE
   typename enable_if<!is_same<RhsPacketType,RhsPacketx4>::value>::type
   madd(const LhsPacketType& a, const RhsPacketType& b, DoublePacket<ResPacketType>& c, TmpType& /*tmp*/, const LaneIdType&) const
@@ -904,6 +971,7 @@ public:
   }
 
   template<typename LaneIdType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd(const LhsPacket& a, const RhsPacket& b, ResPacket& c, RhsPacket& /*tmp*/, const LaneIdType&) const
   {
     c = cj.pmadd(a,b,c);
@@ -915,9 +983,11 @@ public:
     madd(a, b.get(lane), c, tmp, lane);
   }
   
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void acc(const Scalar& c, const Scalar& alpha, Scalar& r) const { r += alpha * c; }
   
   template<typename RealPacketType, typename ResPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void acc(const DoublePacket<RealPacketType>& c, const ResPacketType& alpha, ResPacketType& r) const
   {
     // assemble c
@@ -995,12 +1065,14 @@ public:
   typedef QuadPacket<RhsPacket> RhsPacketx4;
   typedef ResPacket AccPacket;
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void initAcc(AccPacket& p)
   {
     p = pset1<ResPacket>(ResScalar(0));
   }
 
   template<typename RhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhs(const RhsScalar* b, RhsPacketType& dest) const
   {
     dest = pset1<RhsPacketType>(*b);
@@ -1017,32 +1089,38 @@ public:
     loadRhs(b, dest);
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void updateRhs(const RhsScalar*, RhsPacketx4&) const
   {}
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhs(const LhsScalar* a, LhsPacket& dest) const
   {
     dest = ploaddup<LhsPacket>(a);
   }
   
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadRhsQuad(const RhsScalar* b, RhsPacket& dest) const
   {
     dest = ploadquad<RhsPacket>(b);
   }
 
   template<typename LhsPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void loadLhsUnaligned(const LhsScalar* a, LhsPacketType& dest) const
   {
     dest = ploaddup<LhsPacketType>(a);
   }
 
   template <typename LhsPacketType, typename RhsPacketType, typename AccPacketType, typename LaneIdType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd(const LhsPacketType& a, const RhsPacketType& b, AccPacketType& c, RhsPacketType& tmp, const LaneIdType&) const
   {
     madd_impl(a, b, c, tmp, typename conditional<Vectorizable,true_type,false_type>::type());
   }
 
   template <typename LhsPacketType, typename RhsPacketType, typename AccPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd_impl(const LhsPacketType& a, const RhsPacketType& b, AccPacketType& c, RhsPacketType& tmp, const true_type&) const
   {
 #ifdef EIGEN_HAS_SINGLE_INSTRUCTION_MADD
@@ -1054,6 +1132,7 @@ public:
     
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void madd_impl(const LhsScalar& a, const RhsScalar& b, ResScalar& c, RhsScalar& /*tmp*/, const false_type&) const
   {
     c += a * b;
@@ -1066,6 +1145,7 @@ public:
   }
 
   template <typename ResPacketType, typename AccPacketType>
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void acc(const AccPacketType& c, const ResPacketType& alpha, ResPacketType& r) const
   {
     conj_helper<ResPacketType,ResPacketType,false,ConjRhs> cj;
@@ -1272,6 +1352,7 @@ struct gebp_kernel
     ResPacketSize = Traits::ResPacketSize
   };
 
+  EIGEN_DEVICE_FUNC
   EIGEN_DONT_INLINE
   void operator()(const DataMapper& res, const LhsScalar* blockA, const RhsScalar* blockB,
                   Index rows, Index depth, Index cols, ResScalar alpha,
@@ -1572,6 +1653,7 @@ EIGEN_STRONG_INLINE void peeled_kc_onestep(Index K, const LhsScalar* blA, const 
 };
 
 template<typename LhsScalar, typename RhsScalar, typename Index, typename DataMapper, int mr, int nr, bool ConjugateLhs, bool ConjugateRhs>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE
 void gebp_kernel<LhsScalar,RhsScalar,Index,DataMapper,mr,nr,ConjugateLhs,ConjugateRhs>
   ::operator()(const DataMapper& res, const LhsScalar* blockA, const RhsScalar* blockB,
@@ -2263,10 +2345,12 @@ template<typename Scalar, typename Index, typename DataMapper, int Pack1, int Pa
 struct gemm_pack_lhs<Scalar, Index, DataMapper, Pack1, Pack2, Packet, ColMajor, Conjugate, PanelMode>
 {
   typedef typename DataMapper::LinearMapper LinearMapper;
+  EIGEN_DEVICE_FUNC
   EIGEN_DONT_INLINE void operator()(Scalar* blockA, const DataMapper& lhs, Index depth, Index rows, Index stride=0, Index offset=0);
 };
 
 template<typename Scalar, typename Index, typename DataMapper, int Pack1, int Pack2, typename Packet, bool Conjugate, bool PanelMode>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void gemm_pack_lhs<Scalar, Index, DataMapper, Pack1, Pack2, Packet, ColMajor, Conjugate, PanelMode>
   ::operator()(Scalar* blockA, const DataMapper& lhs, Index depth, Index rows, Index stride, Index offset)
 {
@@ -2553,10 +2637,12 @@ struct gemm_pack_rhs<Scalar, Index, DataMapper, nr, ColMajor, Conjugate, PanelMo
   typedef typename packet_traits<Scalar>::type Packet;
   typedef typename DataMapper::LinearMapper LinearMapper;
   enum { PacketSize = packet_traits<Scalar>::size };
+  EIGEN_DEVICE_FUNC
   EIGEN_DONT_INLINE void operator()(Scalar* blockB, const DataMapper& rhs, Index depth, Index cols, Index stride=0, Index offset=0);
 };
 
 template<typename Scalar, typename Index, typename DataMapper, int nr, bool Conjugate, bool PanelMode>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void gemm_pack_rhs<Scalar, Index, DataMapper, nr, ColMajor, Conjugate, PanelMode>
   ::operator()(Scalar* blockB, const DataMapper& rhs, Index depth, Index cols, Index stride, Index offset)
 {

--- a/Eigen/src/Core/products/GeneralMatrixMatrix.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrix.h
@@ -263,16 +263,17 @@ class level3_blocking
 
   public:
 
+    EIGEN_DEVICE_FUNC
     level3_blocking()
       : m_blockA(0), m_blockB(0), m_mc(0), m_nc(0), m_kc(0)
     {}
 
-    inline Index mc() const { return m_mc; }
-    inline Index nc() const { return m_nc; }
-    inline Index kc() const { return m_kc; }
+    EIGEN_DEVICE_FUNC inline Index mc() const { return m_mc; }
+    EIGEN_DEVICE_FUNC inline Index nc() const { return m_nc; }
+    EIGEN_DEVICE_FUNC inline Index kc() const { return m_kc; }
 
-    inline LhsScalar* blockA() { return m_blockA; }
-    inline RhsScalar* blockB() { return m_blockB; }
+    EIGEN_DEVICE_FUNC inline LhsScalar* blockA() { return m_blockA; }
+    EIGEN_DEVICE_FUNC inline RhsScalar* blockB() { return m_blockB; }
 };
 
 template<int StorageOrder, typename _LhsScalar, typename _RhsScalar, int MaxRows, int MaxCols, int MaxDepth, int KcFactor>
@@ -304,6 +305,7 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
 
   public:
 
+    EIGEN_DEVICE_FUNC
     gemm_blocking_space(Index /*rows*/, Index /*cols*/, Index /*depth*/, Index /*num_threads*/, bool /*full_rows = false*/)
     {
       this->m_mc = ActualRows;
@@ -344,6 +346,7 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
 
   public:
 
+    EIGEN_DEVICE_FUNC
     gemm_blocking_space(Index rows, Index cols, Index depth, Index num_threads, bool l3_blocking)
     {
       this->m_mc = Transpose ? cols : rows;
@@ -395,6 +398,7 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
       allocateB();
     }
 
+    EIGEN_DEVICE_FUNC
     ~gemm_blocking_space()
     {
       aligned_delete(this->m_blockA, m_sizeA);

--- a/Eigen/src/Core/products/GeneralMatrixMatrix.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrix.h
@@ -320,12 +320,12 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
 #endif
     }
 
-    void initParallel(Index, Index, Index, Index)
+    EIGEN_DEVICE_FUNC void initParallel(Index, Index, Index, Index)
     {}
 
-    inline void allocateA() {}
-    inline void allocateB() {}
-    inline void allocateAll() {}
+    EIGEN_DEVICE_FUNC inline void allocateA() {}
+    EIGEN_DEVICE_FUNC inline void allocateB() {}
+    EIGEN_DEVICE_FUNC inline void allocateAll() {}
 };
 
 template<int StorageOrder, typename _LhsScalar, typename _RhsScalar, int MaxRows, int MaxCols, int MaxDepth, int KcFactor>
@@ -367,7 +367,7 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
       m_sizeB = this->m_kc * this->m_nc;
     }
 
-    void initParallel(Index rows, Index cols, Index depth, Index num_threads)
+    EIGEN_DEVICE_FUNC void initParallel(Index rows, Index cols, Index depth, Index num_threads)
     {
       this->m_mc = Transpose ? cols : rows;
       this->m_nc = Transpose ? rows : cols;
@@ -380,19 +380,19 @@ class gemm_blocking_space<StorageOrder,_LhsScalar,_RhsScalar,MaxRows, MaxCols, M
       m_sizeB = this->m_kc * this->m_nc;
     }
 
-    void allocateA()
+    EIGEN_DEVICE_FUNC void allocateA()
     {
       if(this->m_blockA==0)
         this->m_blockA = aligned_new<LhsScalar>(m_sizeA);
     }
 
-    void allocateB()
+    EIGEN_DEVICE_FUNC void allocateB()
     {
       if(this->m_blockB==0)
         this->m_blockB = aligned_new<RhsScalar>(m_sizeB);
     }
 
-    void allocateAll()
+    EIGEN_DEVICE_FUNC void allocateAll()
     {
       allocateA();
       allocateB();

--- a/Eigen/src/Core/products/GeneralMatrixMatrixTriangular.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrixTriangular.h
@@ -60,6 +60,8 @@ template <typename Index, typename LhsScalar, int LhsStorageOrder, bool Conjugat
 struct general_matrix_matrix_triangular_product<Index,LhsScalar,LhsStorageOrder,ConjugateLhs,RhsScalar,RhsStorageOrder,ConjugateRhs,ColMajor,ResInnerStride,UpLo,Version>
 {
   typedef typename ScalarBinaryOpTraits<LhsScalar, RhsScalar>::ReturnType ResScalar;
+
+  EIGEN_DEVICE_FUNC
   static EIGEN_STRONG_INLINE void run(Index size, Index depth,const LhsScalar* _lhs, Index lhsStride,
                                       const RhsScalar* _rhs, Index rhsStride,
                                       ResScalar* _res, Index resIncr, Index resStride,
@@ -144,6 +146,7 @@ struct tribb_kernel
   enum {
     BlockSize  = meta_least_common_multiple<EIGEN_PLAIN_ENUM_MAX(mr,nr),EIGEN_PLAIN_ENUM_MIN(mr,nr)>::ret
   };
+  EIGEN_DEVICE_FUNC
   void operator()(ResScalar* _res, Index resIncr, Index resStride, const LhsScalar* blockA, const RhsScalar* blockB, Index size, Index depth, const ResScalar& alpha)
   {
     typedef blas_data_mapper<ResScalar, Index, ColMajor, Unaligned, ResInnerStride> ResMapper;
@@ -252,6 +255,7 @@ struct general_product_to_triangular_selector<MatrixType,ProductType,UpLo,true>
 template<typename MatrixType, typename ProductType, int UpLo>
 struct general_product_to_triangular_selector<MatrixType,ProductType,UpLo,false>
 {
+  EIGEN_DEVICE_FUNC
   static void run(MatrixType& mat, const ProductType& prod, const typename MatrixType::Scalar& alpha, bool beta)
   {
     typedef typename internal::remove_all<typename ProductType::LhsNested>::type Lhs;

--- a/Eigen/src/Core/products/GeneralMatrixMatrixTriangular.h
+++ b/Eigen/src/Core/products/GeneralMatrixMatrixTriangular.h
@@ -42,7 +42,7 @@ template <typename Index, typename LhsScalar, int LhsStorageOrder, bool Conjugat
 struct general_matrix_matrix_triangular_product<Index,LhsScalar,LhsStorageOrder,ConjugateLhs,RhsScalar,RhsStorageOrder,ConjugateRhs,RowMajor,ResInnerStride,UpLo,Version>
 {
   typedef typename ScalarBinaryOpTraits<LhsScalar, RhsScalar>::ReturnType ResScalar;
-  static EIGEN_STRONG_INLINE void run(Index size, Index depth,const LhsScalar* lhs, Index lhsStride,
+  EIGEN_DEVICE_FUNC static EIGEN_STRONG_INLINE void run(Index size, Index depth,const LhsScalar* lhs, Index lhsStride,
                                       const RhsScalar* rhs, Index rhsStride, ResScalar* res, Index resIncr, Index resStride,
                                       const ResScalar& alpha, level3_blocking<RhsScalar,LhsScalar>& blocking)
   {
@@ -207,6 +207,7 @@ struct general_product_to_triangular_selector;
 template<typename MatrixType, typename ProductType, int UpLo>
 struct general_product_to_triangular_selector<MatrixType,ProductType,UpLo,true>
 {
+  EIGEN_DEVICE_FUNC
   static void run(MatrixType& mat, const ProductType& prod, const typename MatrixType::Scalar& alpha, bool beta)
   {
     typedef typename MatrixType::Scalar Scalar;

--- a/Eigen/src/Core/products/SelfadjointMatrixMatrix.h
+++ b/Eigen/src/Core/products/SelfadjointMatrixMatrix.h
@@ -101,6 +101,8 @@ template<typename Scalar, typename Index, int nr, int StorageOrder>
 struct symm_pack_rhs
 {
   enum { PacketSize = packet_traits<Scalar>::size };
+
+  EIGEN_DEVICE_FUNC
   void operator()(Scalar* blockB, const Scalar* _rhs, Index rhsStride, Index rows, Index cols, Index k2)
   {
     Index end_k = k2 + rows;
@@ -423,6 +425,7 @@ template <typename Scalar, typename Index,
 struct product_selfadjoint_matrix<Scalar,Index,LhsStorageOrder,false,ConjugateLhs, RhsStorageOrder,true,ConjugateRhs,ColMajor,ResInnerStride>
 {
 
+  EIGEN_DEVICE_FUNC
   static EIGEN_DONT_INLINE void run(
     Index rows, Index cols,
     const Scalar* _lhs, Index lhsStride,
@@ -435,7 +438,7 @@ template <typename Scalar, typename Index,
           int LhsStorageOrder, bool ConjugateLhs,
           int RhsStorageOrder, bool ConjugateRhs,
           int ResInnerStride>
-EIGEN_DONT_INLINE void product_selfadjoint_matrix<Scalar,Index,LhsStorageOrder,false,ConjugateLhs, RhsStorageOrder,true,ConjugateRhs,ColMajor,ResInnerStride>::run(
+EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void product_selfadjoint_matrix<Scalar,Index,LhsStorageOrder,false,ConjugateLhs, RhsStorageOrder,true,ConjugateRhs,ColMajor,ResInnerStride>::run(
     Index rows, Index cols,
     const Scalar* _lhs, Index lhsStride,
     const Scalar* _rhs, Index rhsStride,
@@ -505,6 +508,7 @@ struct selfadjoint_product_impl<Lhs,LhsMode,false,Rhs,RhsMode,false>
   };
   
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(Dest &dst, const Lhs &a_lhs, const Rhs &a_rhs, const Scalar& alpha)
   {
     eigen_assert(dst.rows()==a_lhs.rows() && dst.cols()==a_rhs.cols());

--- a/Eigen/src/Core/products/SelfadjointMatrixVector.h
+++ b/Eigen/src/Core/products/SelfadjointMatrixVector.h
@@ -246,7 +246,8 @@ struct selfadjoint_product_impl<Lhs,0,true,Rhs,RhsMode,false>
   enum { RhsUpLo = RhsMode&(Upper|Lower)  };
 
   template<typename Dest>
-  static void run(Dest& dest, const Lhs &a_lhs, const Rhs &a_rhs, const Scalar& alpha)
+  static EIGEN_DEVICE_FUNC
+  void run(Dest& dest, const Lhs &a_lhs, const Rhs &a_rhs, const Scalar& alpha)
   {
     // let's simply transpose the product
     Transpose<Dest> destT(dest);

--- a/Eigen/src/Core/products/SelfadjointProduct.h
+++ b/Eigen/src/Core/products/SelfadjointProduct.h
@@ -50,6 +50,7 @@ struct selfadjoint_product_selector;
 template<typename MatrixType, typename OtherType, int UpLo>
 struct selfadjoint_product_selector<MatrixType,OtherType,UpLo,true>
 {
+  EIGEN_DEVICE_FUNC
   static void run(MatrixType& mat, const OtherType& other, const typename MatrixType::Scalar& alpha)
   {
     typedef typename MatrixType::Scalar Scalar;
@@ -82,6 +83,7 @@ struct selfadjoint_product_selector<MatrixType,OtherType,UpLo,true>
 template<typename MatrixType, typename OtherType, int UpLo>
 struct selfadjoint_product_selector<MatrixType,OtherType,UpLo,false>
 {
+  EIGEN_DEVICE_FUNC
   static void run(MatrixType& mat, const OtherType& other, const typename MatrixType::Scalar& alpha)
   {
     typedef typename MatrixType::Scalar Scalar;

--- a/Eigen/src/Core/products/TriangularMatrixMatrix.h
+++ b/Eigen/src/Core/products/TriangularMatrixMatrix.h
@@ -58,6 +58,7 @@ struct product_triangular_matrix_matrix<Scalar,Index,Mode,LhsIsTriangular,
                                            LhsStorageOrder,ConjugateLhs,
                                            RhsStorageOrder,ConjugateRhs,RowMajor,ResInnerStride,Version>
 {
+  EIGEN_DEVICE_FUNC
   static EIGEN_STRONG_INLINE void run(
     Index rows, Index cols, Index depth,
     const Scalar* lhs, Index lhsStride,
@@ -94,6 +95,7 @@ struct product_triangular_matrix_matrix<Scalar,Index,Mode,true,
     SetDiag = (Mode&(ZeroDiag|UnitDiag)) ? 0 : 1
   };
 
+  EIGEN_DEVICE_FUNC
   static EIGEN_DONT_INLINE void run(
     Index _rows, Index _cols, Index _depth,
     const Scalar* _lhs, Index lhsStride,
@@ -106,6 +108,7 @@ template <typename Scalar, typename Index, int Mode,
           int LhsStorageOrder, bool ConjugateLhs,
           int RhsStorageOrder, bool ConjugateRhs,
           int ResInnerStride, int Version>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void product_triangular_matrix_matrix<Scalar,Index,Mode,true,
                                                         LhsStorageOrder,ConjugateLhs,
                                                         RhsStorageOrder,ConjugateRhs,ColMajor,ResInnerStride,Version>::run(
@@ -252,6 +255,7 @@ struct product_triangular_matrix_matrix<Scalar,Index,Mode,false,
     SetDiag = (Mode&(ZeroDiag|UnitDiag)) ? 0 : 1
   };
 
+  EIGEN_DEVICE_FUNC
   static EIGEN_DONT_INLINE void run(
     Index _rows, Index _cols, Index _depth,
     const Scalar* _lhs, Index lhsStride,
@@ -264,6 +268,7 @@ template <typename Scalar, typename Index, int Mode,
           int LhsStorageOrder, bool ConjugateLhs,
           int RhsStorageOrder, bool ConjugateRhs,
           int ResInnerStride, int Version>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void product_triangular_matrix_matrix<Scalar,Index,Mode,false,
                                                         LhsStorageOrder,ConjugateLhs,
                                                         RhsStorageOrder,ConjugateRhs,ColMajor,ResInnerStride,Version>::run(
@@ -404,7 +409,9 @@ namespace internal {
 template<int Mode, bool LhsIsTriangular, typename Lhs, typename Rhs>
 struct triangular_product_impl<Mode,LhsIsTriangular,Lhs,false,Rhs,false>
 {
-  template<typename Dest> static void run(Dest& dst, const Lhs &a_lhs, const Rhs &a_rhs, const typename Dest::Scalar& alpha)
+  template<typename Dest>
+  EIGEN_DEVICE_FUNC
+  static void run(Dest& dst, const Lhs &a_lhs, const Rhs &a_rhs, const typename Dest::Scalar& alpha)
   {
     typedef typename Lhs::Scalar  LhsScalar;
     typedef typename Rhs::Scalar  RhsScalar;

--- a/Eigen/src/Core/products/TriangularMatrixVector.h
+++ b/Eigen/src/Core/products/TriangularMatrixVector.h
@@ -26,11 +26,13 @@ struct triangular_matrix_vector_product<Index,Mode,LhsScalar,ConjLhs,RhsScalar,C
     HasUnitDiag = (Mode & UnitDiag)==UnitDiag,
     HasZeroDiag = (Mode & ZeroDiag)==ZeroDiag
   };
+  EIGEN_DEVICE_FUNC
   static EIGEN_DONT_INLINE  void run(Index _rows, Index _cols, const LhsScalar* _lhs, Index lhsStride,
                                      const RhsScalar* _rhs, Index rhsIncr, ResScalar* _res, Index resIncr, const RhsScalar& alpha);
 };
 
 template<typename Index, int Mode, typename LhsScalar, bool ConjLhs, typename RhsScalar, bool ConjRhs, int Version>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void triangular_matrix_vector_product<Index,Mode,LhsScalar,ConjLhs,RhsScalar,ConjRhs,ColMajor,Version>
   ::run(Index _rows, Index _cols, const LhsScalar* _lhs, Index lhsStride,
         const RhsScalar* _rhs, Index rhsIncr, ResScalar* _res, Index resIncr, const RhsScalar& alpha)
@@ -97,11 +99,13 @@ struct triangular_matrix_vector_product<Index,Mode,LhsScalar,ConjLhs,RhsScalar,C
     HasUnitDiag = (Mode & UnitDiag)==UnitDiag,
     HasZeroDiag = (Mode & ZeroDiag)==ZeroDiag
   };
+  EIGEN_DEVICE_FUNC
   static EIGEN_DONT_INLINE void run(Index _rows, Index _cols, const LhsScalar* _lhs, Index lhsStride,
                                     const RhsScalar* _rhs, Index rhsIncr, ResScalar* _res, Index resIncr, const ResScalar& alpha);
 };
 
 template<typename Index, int Mode, typename LhsScalar, bool ConjLhs, typename RhsScalar, bool ConjRhs,int Version>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void triangular_matrix_vector_product<Index,Mode,LhsScalar,ConjLhs,RhsScalar,ConjRhs,RowMajor,Version>
   ::run(Index _rows, Index _cols, const LhsScalar* _lhs, Index lhsStride,
         const RhsScalar* _rhs, Index rhsIncr, ResScalar* _res, Index resIncr, const ResScalar& alpha)
@@ -173,7 +177,9 @@ namespace internal {
 template<int Mode, typename Lhs, typename Rhs>
 struct triangular_product_impl<Mode,true,Lhs,false,Rhs,true>
 {
-  template<typename Dest> static void run(Dest& dst, const Lhs &lhs, const Rhs &rhs, const typename Dest::Scalar& alpha)
+  template<typename Dest>
+  EIGEN_DEVICE_FUNC
+  static void run(Dest& dst, const Lhs &lhs, const Rhs &rhs, const typename Dest::Scalar& alpha)
   {
     eigen_assert(dst.rows()==lhs.rows() && dst.cols()==rhs.cols());
   
@@ -184,7 +190,9 @@ struct triangular_product_impl<Mode,true,Lhs,false,Rhs,true>
 template<int Mode, typename Lhs, typename Rhs>
 struct triangular_product_impl<Mode,false,Lhs,true,Rhs,false>
 {
-  template<typename Dest> static void run(Dest& dst, const Lhs &lhs, const Rhs &rhs, const typename Dest::Scalar& alpha)
+  template<typename Dest>
+  EIGEN_DEVICE_FUNC
+  static void run(Dest& dst, const Lhs &lhs, const Rhs &rhs, const typename Dest::Scalar& alpha)
   {
     eigen_assert(dst.rows()==lhs.rows() && dst.cols()==rhs.cols());
 
@@ -204,6 +212,7 @@ namespace internal {
 template<int Mode> struct trmv_selector<Mode,ColMajor>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     typedef typename Lhs::Scalar      LhsScalar;
@@ -287,6 +296,7 @@ template<int Mode> struct trmv_selector<Mode,ColMajor>
 template<int Mode> struct trmv_selector<Mode,RowMajor>
 {
   template<typename Lhs, typename Rhs, typename Dest>
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs &lhs, const Rhs &rhs, Dest& dest, const typename Dest::Scalar& alpha)
   {
     typedef typename Lhs::Scalar      LhsScalar;

--- a/Eigen/src/Core/products/TriangularSolverMatrix.h
+++ b/Eigen/src/Core/products/TriangularSolverMatrix.h
@@ -38,14 +38,14 @@ struct triangular_solve_matrix<Scalar,Index,Side,Mode,Conjugate,TriStorageOrder,
 template <typename Scalar, typename Index, int Mode, bool Conjugate, int TriStorageOrder,int OtherInnerStride>
 struct triangular_solve_matrix<Scalar,Index,OnTheLeft,Mode,Conjugate,TriStorageOrder,ColMajor,OtherInnerStride>
 {
-  static EIGEN_DONT_INLINE void run(
+  static EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void run(
     Index size, Index otherSize,
     const Scalar* _tri, Index triStride,
     Scalar* _other, Index otherIncr, Index otherStride,
     level3_blocking<Scalar,Scalar>& blocking);
 };
 template <typename Scalar, typename Index, int Mode, bool Conjugate, int TriStorageOrder, int OtherInnerStride>
-EIGEN_DONT_INLINE void triangular_solve_matrix<Scalar,Index,OnTheLeft,Mode,Conjugate,TriStorageOrder,ColMajor,OtherInnerStride>::run(
+EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void triangular_solve_matrix<Scalar,Index,OnTheLeft,Mode,Conjugate,TriStorageOrder,ColMajor,OtherInnerStride>::run(
     Index size, Index otherSize,
     const Scalar* _tri, Index triStride,
     Scalar* _other, Index otherIncr, Index otherStride,
@@ -61,7 +61,7 @@ EIGEN_DONT_INLINE void triangular_solve_matrix<Scalar,Index,OnTheLeft,Mode,Conju
     typedef gebp_traits<Scalar,Scalar> Traits;
 
     enum {
-      SmallPanelWidth   = EIGEN_PLAIN_ENUM_MAX(Traits::mr,Traits::nr),
+      SmallPanelWidth = EIGEN_PLAIN_ENUM_MAX(Traits::mr,Traits::nr),
       IsLower = (Mode&Lower) == Lower
     };
 

--- a/Eigen/src/Core/products/TriangularSolverMatrix.h
+++ b/Eigen/src/Core/products/TriangularSolverMatrix.h
@@ -18,6 +18,7 @@ namespace internal {
 template <typename Scalar, typename Index, int Side, int Mode, bool Conjugate, int TriStorageOrder, int OtherInnerStride>
 struct triangular_solve_matrix<Scalar,Index,Side,Mode,Conjugate,TriStorageOrder,RowMajor,OtherInnerStride>
 {
+  EIGEN_DEVICE_FUNC
   static void run(
     Index size, Index cols,
     const Scalar*  tri, Index triStride,
@@ -190,6 +191,7 @@ EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE void triangular_solve_matrix<Scalar,Index,On
 template <typename Scalar, typename Index, int Mode, bool Conjugate, int TriStorageOrder, int OtherInnerStride>
 struct triangular_solve_matrix<Scalar,Index,OnTheRight,Mode,Conjugate,TriStorageOrder,ColMajor,OtherInnerStride>
 {
+  EIGEN_DEVICE_FUNC
   static EIGEN_DONT_INLINE void run(
     Index size, Index otherSize,
     const Scalar* _tri, Index triStride,
@@ -197,6 +199,7 @@ struct triangular_solve_matrix<Scalar,Index,OnTheRight,Mode,Conjugate,TriStorage
     level3_blocking<Scalar,Scalar>& blocking);
 };
 template <typename Scalar, typename Index, int Mode, bool Conjugate, int TriStorageOrder, int OtherInnerStride>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE void triangular_solve_matrix<Scalar,Index,OnTheRight,Mode,Conjugate,TriStorageOrder,ColMajor,OtherInnerStride>::run(
     Index size, Index otherSize,
     const Scalar* _tri, Index triStride,

--- a/Eigen/src/Core/products/TriangularSolverMatrix_BLAS.h
+++ b/Eigen/src/Core/products/TriangularSolverMatrix_BLAS.h
@@ -48,6 +48,7 @@ struct triangular_solve_matrix<EIGTYPE,Index,OnTheLeft,Mode,Conjugate,TriStorage
     IsZeroDiag  = (Mode&ZeroDiag) ? 1 : 0, \
     conjA = ((TriStorageOrder==ColMajor) && Conjugate) ? 1 : 0 \
   }; \
+  EIGEN_DEVICE_FUNC
   static void run( \
       Index size, Index otherSize, \
       const EIGTYPE* _tri, Index triStride, \
@@ -109,6 +110,7 @@ struct triangular_solve_matrix<EIGTYPE,Index,OnTheRight,Mode,Conjugate,TriStorag
     IsZeroDiag  = (Mode&ZeroDiag) ? 1 : 0, \
     conjA = ((TriStorageOrder==ColMajor) && Conjugate) ? 1 : 0 \
   }; \
+  EIGEN_DEVICE_FUNC
   static void run( \
       Index size, Index otherSize, \
       const EIGTYPE* _tri, Index triStride, \

--- a/Eigen/src/Core/products/TriangularSolverVector.h
+++ b/Eigen/src/Core/products/TriangularSolverVector.h
@@ -17,6 +17,7 @@ namespace internal {
 template<typename LhsScalar, typename RhsScalar, typename Index, int Mode, bool Conjugate, int StorageOrder>
 struct triangular_solve_vector<LhsScalar, RhsScalar, Index, OnTheRight, Mode, Conjugate, StorageOrder>
 {
+  EIGEN_DEVICE_FUNC
   static void run(Index size, const LhsScalar* _lhs, Index lhsStride, RhsScalar* rhs)
   {
     triangular_solve_vector<LhsScalar,RhsScalar,Index,OnTheLeft,
@@ -33,6 +34,7 @@ struct triangular_solve_vector<LhsScalar, RhsScalar, Index, OnTheLeft, Mode, Con
   enum {
     IsLower = ((Mode&Lower)==Lower)
   };
+  EIGEN_DEVICE_FUNC
   static void run(Index size, const LhsScalar* _lhs, Index lhsStride, RhsScalar* rhs)
   {
     typedef Map<const Matrix<LhsScalar,Dynamic,Dynamic,RowMajor>, 0, OuterStride<> > LhsMap;
@@ -91,6 +93,7 @@ struct triangular_solve_vector<LhsScalar, RhsScalar, Index, OnTheLeft, Mode, Con
   enum {
     IsLower = ((Mode&Lower)==Lower)
   };
+  EIGEN_DEVICE_FUNC
   static void run(Index size, const LhsScalar* _lhs, Index lhsStride, RhsScalar* rhs)
   {
     typedef Map<const Matrix<LhsScalar,Dynamic,Dynamic,ColMajor>, 0, OuterStride<> > LhsMap;

--- a/Eigen/src/Core/util/BlasUtil.h
+++ b/Eigen/src/Core/util/BlasUtil.h
@@ -51,8 +51,11 @@ template<> struct conj_if<true> {
 
 template<> struct conj_if<false> {
   template<typename T>
+  EIGEN_DEVICE_FUNC
   inline const T& operator()(const T& x) const { return x; }
+
   template<typename T>
+  EIGEN_DEVICE_FUNC
   inline const T& pconj(const T& x) const { return x; }
 };
 
@@ -472,9 +475,9 @@ protected:
 template<typename Scalar, typename Index, int StorageOrder>
 class const_blas_data_mapper : public blas_data_mapper<const Scalar, Index, StorageOrder> {
   public:
-  EIGEN_ALWAYS_INLINE const_blas_data_mapper(const Scalar *data, Index stride) : blas_data_mapper<const Scalar, Index, StorageOrder>(data, stride) {}
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE const_blas_data_mapper(const Scalar *data, Index stride) : blas_data_mapper<const Scalar, Index, StorageOrder>(data, stride) {}
 
-  EIGEN_ALWAYS_INLINE const_blas_data_mapper<Scalar, Index, StorageOrder> getSubMapper(Index i, Index j) const {
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE const_blas_data_mapper<Scalar, Index, StorageOrder> getSubMapper(Index i, Index j) const {
     return const_blas_data_mapper<Scalar, Index, StorageOrder>(&(this->operator()(i, j)), this->m_stride);
   }
 };

--- a/Eigen/src/Core/util/BlasUtil.h
+++ b/Eigen/src/Core/util/BlasUtil.h
@@ -594,8 +594,8 @@ struct blas_traits<Transpose<NestedXpr> >
   enum {
     IsTransposed = Base::IsTransposed ? 0 : 1
   };
-  static inline ExtractType extract(const XprType& x) { return ExtractType(Base::extract(x.nestedExpression())); }
-  static inline Scalar extractScalarFactor(const XprType& x) { return Base::extractScalarFactor(x.nestedExpression()); }
+  EIGEN_DEVICE_FUNC static inline ExtractType extract(const XprType& x) { return ExtractType(Base::extract(x.nestedExpression())); }
+  EIGEN_DEVICE_FUNC static inline Scalar extractScalarFactor(const XprType& x) { return Base::extractScalarFactor(x.nestedExpression()); }
 };
 
 template<typename T>

--- a/Eigen/src/Core/util/BlasUtil.h
+++ b/Eigen/src/Core/util/BlasUtil.h
@@ -44,8 +44,10 @@ template<bool Conjugate> struct conj_if;
 
 template<> struct conj_if<true> {
   template<typename T>
+  EIGEN_DEVICE_FUNC
   inline T operator()(const T& x) const { return numext::conj(x); }
   template<typename T>
+  EIGEN_DEVICE_FUNC
   inline T pconj(const T& x) const { return internal::pconj(x); }
 };
 
@@ -522,8 +524,8 @@ struct blas_traits<CwiseUnaryOp<scalar_conjugate_op<Scalar>, NestedXpr> >
     IsComplex = NumTraits<Scalar>::IsComplex,
     NeedToConjugate = Base::NeedToConjugate ? 0 : IsComplex
   };
-  static inline ExtractType extract(const XprType& x) { return Base::extract(x.nestedExpression()); }
-  static inline Scalar extractScalarFactor(const XprType& x) { return conj(Base::extractScalarFactor(x.nestedExpression())); }
+  EIGEN_DEVICE_FUNC static inline ExtractType extract(const XprType& x) { return Base::extract(x.nestedExpression()); }
+  EIGEN_DEVICE_FUNC static inline Scalar extractScalarFactor(const XprType& x) { return conj(Base::extractScalarFactor(x.nestedExpression())); }
 };
 
 // pop scalar multiple
@@ -551,8 +553,8 @@ struct blas_traits<CwiseBinaryOp<scalar_product_op<Scalar>, NestedXpr, const Cwi
   typedef blas_traits<NestedXpr> Base;
   typedef CwiseBinaryOp<scalar_product_op<Scalar>, NestedXpr, const CwiseNullaryOp<scalar_constant_op<Scalar>,Plain> > XprType;
   typedef typename Base::ExtractType ExtractType;
-  static inline ExtractType extract(const XprType& x) { return Base::extract(x.lhs()); }
-  static inline Scalar extractScalarFactor(const XprType& x)
+  EIGEN_DEVICE_FUNC static inline ExtractType extract(const XprType& x) { return Base::extract(x.lhs()); }
+  EIGEN_DEVICE_FUNC static inline Scalar extractScalarFactor(const XprType& x)
   { return Base::extractScalarFactor(x.lhs()) * x.rhs().functor().m_other; }
 };
 template<typename Scalar, typename Plain1, typename Plain2>
@@ -572,8 +574,8 @@ struct blas_traits<CwiseUnaryOp<scalar_opposite_op<Scalar>, NestedXpr> >
   typedef blas_traits<NestedXpr> Base;
   typedef CwiseUnaryOp<scalar_opposite_op<Scalar>, NestedXpr> XprType;
   typedef typename Base::ExtractType ExtractType;
-  static inline ExtractType extract(const XprType& x) { return Base::extract(x.nestedExpression()); }
-  static inline Scalar extractScalarFactor(const XprType& x)
+  EIGEN_DEVICE_FUNC static inline ExtractType extract(const XprType& x) { return Base::extract(x.nestedExpression()); }
+  EIGEN_DEVICE_FUNC static inline Scalar extractScalarFactor(const XprType& x)
   { return - Base::extractScalarFactor(x.nestedExpression()); }
 };
 
@@ -605,6 +607,7 @@ struct blas_traits<const T>
 
 template<typename T, bool HasUsableDirectAccess=blas_traits<T>::HasUsableDirectAccess>
 struct extract_data_selector {
+  EIGEN_DEVICE_FUNC
   static const typename T::Scalar* run(const T& m)
   {
     return blas_traits<T>::extract(m).data();
@@ -613,10 +616,13 @@ struct extract_data_selector {
 
 template<typename T>
 struct extract_data_selector<T,false> {
+  EIGEN_DEVICE_FUNC
   static typename T::Scalar* run(const T&) { return 0; }
 };
 
-template<typename T> const typename T::Scalar* extract_data(const T& m)
+template<typename T>
+EIGEN_DEVICE_FUNC
+const typename T::Scalar* extract_data(const T& m)
 {
   return extract_data_selector<T>::run(m);
 }

--- a/Eigen/src/Core/util/IndexedViewHelper.h
+++ b/Eigen/src/Core/util/IndexedViewHelper.h
@@ -88,6 +88,7 @@ struct IndexedViewCompatibleType {
 };
 
 template<typename T,typename Q>
+EIGEN_DEVICE_FUNC
 const T& makeIndexedViewCompatible(const T& x, Index /*size*/, Q) { return x; }
 
 //--------------------------------------------------------------------------------

--- a/Eigen/src/Core/util/Macros.h
+++ b/Eigen/src/Core/util/Macros.h
@@ -993,7 +993,9 @@ namespace Eigen {
 #define EIGEN_UNUSED_VARIABLE(var) Eigen::internal::ignore_unused_variable(var);
 
 #if !defined(EIGEN_ASM_COMMENT)
-  #if EIGEN_COMP_GNUC && (EIGEN_ARCH_i386_OR_x86_64 || EIGEN_ARCH_ARM_OR_ARM64)
+  #if defined(EIGEN_CUDA_ARCH)
+    #define EIGEN_ASM_COMMENT(X)  __asm__("//" X)
+  #elif EIGEN_COMP_GNUC && (EIGEN_ARCH_i386_OR_x86_64 || EIGEN_ARCH_ARM_OR_ARM64)
     #define EIGEN_ASM_COMMENT(X)  __asm__("#" X)
   #else
     #define EIGEN_ASM_COMMENT(X)

--- a/Eigen/src/Core/util/XprHelper.h
+++ b/Eigen/src/Core/util/XprHelper.h
@@ -19,7 +19,8 @@
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE X() {} \
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE X(const X& ) {}
 #else
-  #define EIGEN_EMPTY_STRUCT_CTOR(X)
+  #define EIGEN_EMPTY_STRUCT_CTOR(X) \
+    EIGEN_DEVICE_FUNC
 #endif
 
 namespace Eigen {

--- a/Eigen/src/Householder/BlockHouseholder.h
+++ b/Eigen/src/Householder/BlockHouseholder.h
@@ -48,6 +48,7 @@ namespace internal {
 /** \internal */
 // This variant avoid modifications in vectors
 template<typename TriangularFactorType,typename VectorsType,typename CoeffsType>
+EIGEN_DEVICE_FUNC
 void make_block_householder_triangular_factor(TriangularFactorType& triFactor, const VectorsType& vectors, const CoeffsType& hCoeffs)
 {
   const Index nbVecs = vectors.cols();
@@ -83,6 +84,7 @@ void make_block_householder_triangular_factor(TriangularFactorType& triFactor, c
   * otherwise perform         mat = H2 * H1 * H0 * mat
   */
 template<typename MatrixType,typename VectorsType,typename CoeffsType>
+EIGEN_DEVICE_FUNC
 void apply_block_householder_on_the_left(MatrixType& mat, const VectorsType& vectors, const CoeffsType& hCoeffs, bool forward)
 {
   enum { TFactorSize = MatrixType::ColsAtCompileTime };

--- a/Eigen/src/Householder/HouseholderSequence.h
+++ b/Eigen/src/Householder/HouseholderSequence.h
@@ -99,6 +99,7 @@ struct hseq_side_dependent_impl<VectorsType, CoeffsType, OnTheRight>
 {
   typedef Transpose<Block<const VectorsType, 1, Dynamic> > EssentialVectorType;
   typedef HouseholderSequence<VectorsType, CoeffsType, OnTheRight> HouseholderSequenceType;
+  EIGEN_DEVICE_FUNC
   static inline const EssentialVectorType essentialVector(const HouseholderSequenceType& h, Index k)
   {
     Index start = k+1+h.m_shift;
@@ -233,6 +234,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
     }
 
     /** \brief %Transpose of the Householder sequence. */
+    EIGEN_DEVICE_FUNC
     TransposeReturnType transpose() const
     {
       return TransposeReturnType(m_vectors.conjugate(), m_coeffs)
@@ -242,6 +244,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
     }
 
     /** \brief Complex conjugate of the Householder sequence. */
+    EIGEN_DEVICE_FUNC
     ConjugateReturnType conjugate() const
     {
       return ConjugateReturnType(m_vectors.conjugate(), m_coeffs.conjugate())
@@ -263,6 +266,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
     }
 
     /** \brief Adjoint (conjugate transpose) of the Householder sequence. */
+    EIGEN_DEVICE_FUNC
     AdjointReturnType adjoint() const
     {
       return AdjointReturnType(m_vectors, m_coeffs.conjugate())
@@ -272,6 +276,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
     }
 
     /** \brief Inverse of the Householder sequence (equals the adjoint). */
+    EIGEN_DEVICE_FUNC
     AdjointReturnType inverse() const { return adjoint(); }
 
     /** \internal */
@@ -338,7 +343,9 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
     }
 
     /** \internal */
-    template<typename Dest> inline void applyThisOnTheRight(Dest& dst) const
+    template<typename Dest>
+    EIGEN_DEVICE_FUNC
+    inline void applyThisOnTheRight(Dest& dst) const
     {
       Matrix<Scalar,1,Dest::RowsAtCompileTime,RowMajor,1,Dest::MaxRowsAtCompileTime> workspace(dst.rows());
       applyThisOnTheRight(dst, workspace);
@@ -346,6 +353,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
 
     /** \internal */
     template<typename Dest, typename Workspace>
+    EIGEN_DEVICE_FUNC
     inline void applyThisOnTheRight(Dest& dst, Workspace& workspace) const
     {
       workspace.resize(dst.rows());
@@ -358,7 +366,9 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
     }
 
     /** \internal */
-    template<typename Dest> inline void applyThisOnTheLeft(Dest& dst, bool inputIsIdentity = false) const
+    template<typename Dest>
+    EIGEN_DEVICE_FUNC
+    inline void applyThisOnTheLeft(Dest& dst, bool inputIsIdentity = false) const
     {
       Matrix<Scalar,1,Dest::ColsAtCompileTime,RowMajor,1,Dest::MaxColsAtCompileTime> workspace;
       applyThisOnTheLeft(dst, workspace, inputIsIdentity);
@@ -366,6 +376,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
 
     /** \internal */
     template<typename Dest, typename Workspace>
+    EIGEN_DEVICE_FUNC
     inline void applyThisOnTheLeft(Dest& dst, Workspace& workspace, bool inputIsIdentity = false) const
     {
       if(inputIsIdentity && m_reverse)
@@ -420,6 +431,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
       * and \f$ M \f$ is the matrix \p other.
       */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     typename internal::matrix_type_times_scalar_type<Scalar, OtherDerived>::Type operator*(const MatrixBase<OtherDerived>& other) const
     {
       typename internal::matrix_type_times_scalar_type<Scalar, OtherDerived>::Type
@@ -485,12 +497,14 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
       *
       * \sa reverseFlag(), transpose(), adjoint()
       */
+    EIGEN_DEVICE_FUNC
     HouseholderSequence& setReverseFlag(bool reverse)
     {
       m_reverse = reverse;
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     bool reverseFlag() const { return m_reverse; }     /**< \internal \brief Returns the reverse flag. */
 
     typename VectorsType::Nested m_vectors;
@@ -510,6 +524,7 @@ template<typename VectorsType, typename CoeffsType, int Side> class HouseholderS
   * Householder sequence represented by \p h.
   */
 template<typename OtherDerived, typename VectorsType, typename CoeffsType, int Side>
+EIGEN_DEVICE_FUNC
 typename internal::matrix_type_times_scalar_type<typename VectorsType::Scalar,OtherDerived>::Type operator*(const MatrixBase<OtherDerived>& other, const HouseholderSequence<VectorsType,CoeffsType,Side>& h)
 {
   typename internal::matrix_type_times_scalar_type<typename VectorsType::Scalar,OtherDerived>::Type
@@ -523,6 +538,7 @@ typename internal::matrix_type_times_scalar_type<typename VectorsType::Scalar,Ot
   * \returns A HouseholderSequence constructed from the specified arguments.
   */
 template<typename VectorsType, typename CoeffsType>
+EIGEN_DEVICE_FUNC
 HouseholderSequence<VectorsType,CoeffsType> householderSequence(const VectorsType& v, const CoeffsType& h)
 {
   return HouseholderSequence<VectorsType,CoeffsType,OnTheLeft>(v, h);
@@ -535,6 +551,7 @@ HouseholderSequence<VectorsType,CoeffsType> householderSequence(const VectorsTyp
   * the constructed HouseholderSequence is set to OnTheRight, instead of the default OnTheLeft.
   */
 template<typename VectorsType, typename CoeffsType>
+EIGEN_DEVICE_FUNC
 HouseholderSequence<VectorsType,CoeffsType,OnTheRight> rightHouseholderSequence(const VectorsType& v, const CoeffsType& h)
 {
   return HouseholderSequence<VectorsType,CoeffsType,OnTheRight>(v, h);

--- a/Eigen/src/Jacobi/Jacobi.h
+++ b/Eigen/src/Jacobi/Jacobi.h
@@ -340,6 +340,7 @@ template<typename Scalar, typename OtherScalar,
          int SizeAtCompileTime, int MinAlignment>
 struct apply_rotation_in_the_plane_selector<Scalar,OtherScalar,SizeAtCompileTime,MinAlignment,true /* vectorizable */>
 {
+  EIGEN_DEVICE_FUNC
   static inline void run(Scalar *x, Index incrx, Scalar *y, Index incry, Index size, OtherScalar c, OtherScalar s)
   {
     enum {

--- a/Eigen/src/LU/PartialPivLU.h
+++ b/Eigen/src/LU/PartialPivLU.h
@@ -97,6 +97,7 @@ template<typename _MatrixType> class PartialPivLU
       * The default constructor is useful in cases in which the user intends to
       * perform decompositions via PartialPivLU::compute(const MatrixType&).
       */
+    EIGEN_DEVICE_FUNC
     PartialPivLU();
 
     /** \brief Default Constructor with memory preallocation
@@ -105,6 +106,7 @@ template<typename _MatrixType> class PartialPivLU
       * according to the specified problem \a size.
       * \sa PartialPivLU()
       */
+    EIGEN_DEVICE_FUNC
     explicit PartialPivLU(Index size);
 
     /** Constructor.
@@ -115,6 +117,7 @@ template<typename _MatrixType> class PartialPivLU
       * If you need to deal with non-full rank, use class FullPivLU instead.
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit PartialPivLU(const EigenBase<InputType>& matrix);
 
     /** Constructor for \link InplaceDecomposition inplace decomposition \endlink
@@ -125,9 +128,17 @@ template<typename _MatrixType> class PartialPivLU
       * If you need to deal with non-full rank, use class FullPivLU instead.
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit PartialPivLU(EigenBase<InputType>& matrix);
 
+    /** Empty destructor
+      */
+    EIGEN_DEVICE_FUNC
+    ~PartialPivLU()
+    {}
+
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     PartialPivLU& compute(const EigenBase<InputType>& matrix) {
       m_lu = matrix.derived();
       compute();
@@ -140,6 +151,7 @@ template<typename _MatrixType> class PartialPivLU
       *
       * \sa matrixL(), matrixU()
       */
+    EIGEN_DEVICE_FUNC
     inline const MatrixType& matrixLU() const
     {
       eigen_assert(m_isInitialized && "PartialPivLU is not initialized.");
@@ -148,6 +160,7 @@ template<typename _MatrixType> class PartialPivLU
 
     /** \returns the permutation matrix P.
       */
+    EIGEN_DEVICE_FUNC
     inline const PermutationType& permutationP() const
     {
       eigen_assert(m_isInitialized && "PartialPivLU is not initialized.");
@@ -173,6 +186,7 @@ template<typename _MatrixType> class PartialPivLU
       * \sa TriangularView::solve(), inverse(), computeInverse()
       */
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<PartialPivLU, Rhs>
     solve(const MatrixBase<Rhs>& b) const;
     #endif
@@ -193,6 +207,7 @@ template<typename _MatrixType> class PartialPivLU
       *
       * \sa MatrixBase::inverse(), LU::inverse()
       */
+    EIGEN_DEVICE_FUNC
     inline const Inverse<PartialPivLU> inverse() const
     {
       eigen_assert(m_isInitialized && "PartialPivLU is not initialized.");
@@ -265,11 +280,13 @@ template<typename _MatrixType> class PartialPivLU
 
   protected:
 
+    EIGEN_DEVICE_FUNC
     static void check_template_parameters()
     {
       EIGEN_STATIC_ASSERT_NON_INTEGER(Scalar);
     }
 
+    EIGEN_DEVICE_FUNC
     void compute();
 
     MatrixType m_lu;
@@ -281,6 +298,7 @@ template<typename _MatrixType> class PartialPivLU
 };
 
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 PartialPivLU<MatrixType>::PartialPivLU()
   : m_lu(),
     m_p(),
@@ -292,6 +310,7 @@ PartialPivLU<MatrixType>::PartialPivLU()
 }
 
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 PartialPivLU<MatrixType>::PartialPivLU(Index size)
   : m_lu(size, size),
     m_p(size),
@@ -304,6 +323,7 @@ PartialPivLU<MatrixType>::PartialPivLU(Index size)
 
 template<typename MatrixType>
 template<typename InputType>
+EIGEN_DEVICE_FUNC
 PartialPivLU<MatrixType>::PartialPivLU(const EigenBase<InputType>& matrix)
   : m_lu(matrix.rows(),matrix.cols()),
     m_p(matrix.rows()),
@@ -317,6 +337,7 @@ PartialPivLU<MatrixType>::PartialPivLU(const EigenBase<InputType>& matrix)
 
 template<typename MatrixType>
 template<typename InputType>
+EIGEN_DEVICE_FUNC
 PartialPivLU<MatrixType>::PartialPivLU(EigenBase<InputType>& matrix)
   : m_lu(matrix.derived()),
     m_p(matrix.rows()),
@@ -355,6 +376,7 @@ struct partial_lu_impl
     *
     * \returns The index of the first pivot which is exactly zero if any, or a negative number otherwise.
     */
+  EIGEN_DEVICE_FUNC
   static Index unblocked_lu(MatrixTypeRef& lu, PivIndex* row_transpositions, PivIndex& nb_transpositions)
   {
     typedef scalar_score_coeff_op<Scalar> Scoring;
@@ -427,6 +449,7 @@ struct partial_lu_impl
     *   1 - reduce the number of instantiations to the strict minimum
     *   2 - avoid infinite recursion of the instantiations with Block<Block<Block<...> > >
     */
+  EIGEN_DEVICE_FUNC
   static Index blocked_lu(Index rows, Index cols, Scalar* lu_data, Index luStride, PivIndex* row_transpositions, PivIndex& nb_transpositions, Index maxBlockSize=256)
   {
     MatrixTypeRef lu = MatrixType::Map(lu_data,rows, cols, OuterStride<>(luStride));
@@ -502,6 +525,7 @@ struct partial_lu_impl
 /** \internal performs the LU decomposition with partial pivoting in-place.
   */
 template<typename MatrixType, typename TranspositionType>
+EIGEN_DEVICE_FUNC
 void partial_lu_inplace(MatrixType& lu, TranspositionType& row_transpositions, typename TranspositionType::StorageIndex& nb_transpositions)
 {
   eigen_assert(lu.cols() == row_transpositions.size());
@@ -517,6 +541,7 @@ void partial_lu_inplace(MatrixType& lu, TranspositionType& row_transpositions, t
 } // end namespace internal
 
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 void PartialPivLU<MatrixType>::compute()
 {
   check_template_parameters();
@@ -577,6 +602,7 @@ struct Assignment<DstXprType, Inverse<PartialPivLU<MatrixType> >, internal::assi
 {
   typedef PartialPivLU<MatrixType> LuType;
   typedef Inverse<LuType> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<typename DstXprType::Scalar,typename LuType::Scalar> &)
   {
     dst = src.nestedExpression().solve(MatrixType::Identity(src.rows(), src.cols()));
@@ -593,6 +619,7 @@ struct Assignment<DstXprType, Inverse<PartialPivLU<MatrixType> >, internal::assi
   * \sa class PartialPivLU
   */
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 inline const PartialPivLU<typename MatrixBase<Derived>::PlainObject>
 MatrixBase<Derived>::partialPivLu() const
 {

--- a/Eigen/src/QR/ColPivHouseholderQR.h
+++ b/Eigen/src/QR/ColPivHouseholderQR.h
@@ -82,6 +82,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
     * The default constructor is useful in cases in which the user intends to
     * perform decompositions via ColPivHouseholderQR::compute(const MatrixType&).
     */
+    EIGEN_DEVICE_FUNC
     ColPivHouseholderQR()
       : m_qr(),
         m_hCoeffs(),
@@ -99,6 +100,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * according to the specified problem \a size.
       * \sa ColPivHouseholderQR()
       */
+    EIGEN_DEVICE_FUNC
     ColPivHouseholderQR(Index rows, Index cols)
       : m_qr(rows, cols),
         m_hCoeffs((std::min)(rows,cols)),
@@ -123,6 +125,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * \sa compute()
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit ColPivHouseholderQR(const EigenBase<InputType>& matrix)
       : m_qr(matrix.rows(), matrix.cols()),
         m_hCoeffs((std::min)(matrix.rows(),matrix.cols())),
@@ -144,6 +147,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * \sa ColPivHouseholderQR(const EigenBase&)
       */
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     explicit ColPivHouseholderQR(EigenBase<InputType>& matrix)
       : m_qr(matrix.derived()),
         m_hCoeffs((std::min)(matrix.rows(),matrix.cols())),
@@ -174,11 +178,14 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * Output: \verbinclude ColPivHouseholderQR_solve.out
       */
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<ColPivHouseholderQR, Rhs>
     solve(const MatrixBase<Rhs>& b) const;
     #endif
 
+    EIGEN_DEVICE_FUNC
     HouseholderSequenceType householderQ() const;
+    EIGEN_DEVICE_FUNC
     HouseholderSequenceType matrixQ() const
     {
       return householderQ();
@@ -186,6 +193,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
 
     /** \returns a reference to the matrix where the Householder QR decomposition is stored
       */
+    EIGEN_DEVICE_FUNC
     const MatrixType& matrixQR() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -201,6 +209,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
      * matrixR().topLeftCorner(rank(), rank()).template triangularView<Upper>()
      * \endcode
      */
+    EIGEN_DEVICE_FUNC
     const MatrixType& matrixR() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -208,9 +217,11 @@ template<typename _MatrixType> class ColPivHouseholderQR
     }
 
     template<typename InputType>
+    EIGEN_DEVICE_FUNC
     ColPivHouseholderQR& compute(const EigenBase<InputType>& matrix);
 
     /** \returns a const reference to the column permutation matrix */
+    EIGEN_DEVICE_FUNC
     const PermutationType& colsPermutation() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -230,6 +241,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *
       * \sa logAbsDeterminant(), MatrixBase::determinant()
       */
+    EIGEN_DEVICE_FUNC
     typename MatrixType::RealScalar absDeterminant() const;
 
     /** \returns the natural log of the absolute value of the determinant of the matrix of which
@@ -244,6 +256,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *
       * \sa absDeterminant(), MatrixBase::determinant()
       */
+    EIGEN_DEVICE_FUNC
     typename MatrixType::RealScalar logAbsDeterminant() const;
 
     /** \returns the rank of the matrix of which *this is the QR decomposition.
@@ -252,6 +265,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *       For that, it uses the threshold value that you can control by calling
       *       setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     inline Index rank() const
     {
       using std::abs;
@@ -269,6 +283,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *       For that, it uses the threshold value that you can control by calling
       *       setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     inline Index dimensionOfKernel() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -282,6 +297,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *       For that, it uses the threshold value that you can control by calling
       *       setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     inline bool isInjective() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -295,6 +311,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *       For that, it uses the threshold value that you can control by calling
       *       setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     inline bool isSurjective() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -307,6 +324,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *       For that, it uses the threshold value that you can control by calling
       *       setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     inline bool isInvertible() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -318,19 +336,23 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * \note If this matrix is not invertible, the returned matrix has undefined coefficients.
       *       Use isInvertible() to first determine whether this matrix is invertible.
       */
+    EIGEN_DEVICE_FUNC
     inline const Inverse<ColPivHouseholderQR> inverse() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
       return Inverse<ColPivHouseholderQR>(*this);
     }
 
+    EIGEN_DEVICE_FUNC
     inline Index rows() const { return m_qr.rows(); }
+    EIGEN_DEVICE_FUNC
     inline Index cols() const { return m_qr.cols(); }
 
     /** \returns a const reference to the vector of Householder coefficients used to represent the factor \c Q.
       *
       * For advanced uses only.
       */
+    EIGEN_DEVICE_FUNC
     const HCoeffsType& hCoeffs() const { return m_hCoeffs; }
 
     /** Allows to prescribe a threshold to be used by certain methods, such as rank(),
@@ -350,6 +372,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *
       * If you want to come back to the default behavior, call setThreshold(Default_t)
       */
+    EIGEN_DEVICE_FUNC
     ColPivHouseholderQR& setThreshold(const RealScalar& threshold)
     {
       m_usePrescribedThreshold = true;
@@ -365,6 +388,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *
       * See the documentation of setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     ColPivHouseholderQR& setThreshold(Default_t)
     {
       m_usePrescribedThreshold = false;
@@ -375,6 +399,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *
       * See the documentation of setThreshold(const RealScalar&).
       */
+    EIGEN_DEVICE_FUNC
     RealScalar threshold() const
     {
       eigen_assert(m_isInitialized || m_usePrescribedThreshold);
@@ -391,6 +416,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       *
       * \sa rank()
       */
+    EIGEN_DEVICE_FUNC
     inline Index nonzeroPivots() const
     {
       eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -400,6 +426,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
     /** \returns the absolute value of the biggest pivot, i.e. the biggest
       *          diagonal coefficient of R.
       */
+    EIGEN_DEVICE_FUNC
     RealScalar maxPivot() const { return m_maxpivot; }
 
     /** \brief Reports whether the QR factorization was successful.
@@ -408,6 +435,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
       * with other factorization routines.
       * \returns \c Success
       */
+    EIGEN_DEVICE_FUNC
     ComputationInfo info() const
     {
       eigen_assert(m_isInitialized && "Decomposition is not initialized.");
@@ -416,6 +444,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
 
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename RhsType, typename DstType>
+    EIGEN_DEVICE_FUNC
     void _solve_impl(const RhsType &rhs, DstType &dst) const;
 
     template<bool Conjugate, typename RhsType, typename DstType>
@@ -426,11 +455,13 @@ template<typename _MatrixType> class ColPivHouseholderQR
 
     friend class CompleteOrthogonalDecomposition<MatrixType>;
 
+    EIGEN_DEVICE_FUNC
     static void check_template_parameters()
     {
       EIGEN_STATIC_ASSERT_NON_INTEGER(Scalar);
     }
 
+    EIGEN_DEVICE_FUNC
     void computeInPlace();
 
     MatrixType m_qr;
@@ -447,6 +478,7 @@ template<typename _MatrixType> class ColPivHouseholderQR
 };
 
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 typename MatrixType::RealScalar ColPivHouseholderQR<MatrixType>::absDeterminant() const
 {
   using std::abs;
@@ -456,6 +488,7 @@ typename MatrixType::RealScalar ColPivHouseholderQR<MatrixType>::absDeterminant(
 }
 
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 typename MatrixType::RealScalar ColPivHouseholderQR<MatrixType>::logAbsDeterminant() const
 {
   eigen_assert(m_isInitialized && "ColPivHouseholderQR is not initialized.");
@@ -471,6 +504,7 @@ typename MatrixType::RealScalar ColPivHouseholderQR<MatrixType>::logAbsDetermina
   */
 template<typename MatrixType>
 template<typename InputType>
+EIGEN_DEVICE_FUNC
 ColPivHouseholderQR<MatrixType>& ColPivHouseholderQR<MatrixType>::compute(const EigenBase<InputType>& matrix)
 {
   m_qr = matrix.derived();
@@ -479,6 +513,7 @@ ColPivHouseholderQR<MatrixType>& ColPivHouseholderQR<MatrixType>::compute(const 
 }
 
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 void ColPivHouseholderQR<MatrixType>::computeInPlace()
 {
   check_template_parameters();
@@ -530,8 +565,8 @@ void ColPivHouseholderQR<MatrixType>::computeInPlace()
     m_colsTranspositions.coeffRef(k) = biggest_col_index;
     if(k != biggest_col_index) {
       m_qr.col(k).swap(m_qr.col(biggest_col_index));
-      std::swap(m_colNormsUpdated.coeffRef(k), m_colNormsUpdated.coeffRef(biggest_col_index));
-      std::swap(m_colNormsDirect.coeffRef(k), m_colNormsDirect.coeffRef(biggest_col_index));
+      numext::swap(m_colNormsUpdated.coeffRef(k), m_colNormsUpdated.coeffRef(biggest_col_index));
+      numext::swap(m_colNormsDirect.coeffRef(k), m_colNormsDirect.coeffRef(biggest_col_index));
       ++number_of_transpositions;
     }
 
@@ -584,6 +619,7 @@ void ColPivHouseholderQR<MatrixType>::computeInPlace()
 #ifndef EIGEN_PARSED_BY_DOXYGEN
 template<typename _MatrixType>
 template<typename RhsType, typename DstType>
+EIGEN_DEVICE_FUNC
 void ColPivHouseholderQR<_MatrixType>::_solve_impl(const RhsType &rhs, DstType &dst) const
 {
   const Index nonzero_pivots = nonzeroPivots();
@@ -639,6 +675,7 @@ struct Assignment<DstXprType, Inverse<ColPivHouseholderQR<MatrixType> >, interna
 {
   typedef ColPivHouseholderQR<MatrixType> QrType;
   typedef Inverse<QrType> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<typename DstXprType::Scalar,typename QrType::Scalar> &)
   {
     dst = src.nestedExpression().solve(MatrixType::Identity(src.rows(), src.cols()));
@@ -651,6 +688,7 @@ struct Assignment<DstXprType, Inverse<ColPivHouseholderQR<MatrixType> >, interna
   * You can extract the meaningful part only by using:
   * \code qr.householderQ().setLength(qr.nonzeroPivots()) \endcode*/
 template<typename MatrixType>
+EIGEN_DEVICE_FUNC
 typename ColPivHouseholderQR<MatrixType>::HouseholderSequenceType ColPivHouseholderQR<MatrixType>
   ::householderQ() const
 {
@@ -663,6 +701,7 @@ typename ColPivHouseholderQR<MatrixType>::HouseholderSequenceType ColPivHousehol
   * \sa class ColPivHouseholderQR
   */
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 const ColPivHouseholderQR<typename MatrixBase<Derived>::PlainObject>
 MatrixBase<Derived>::colPivHouseholderQr() const
 {

--- a/Eigen/src/SparseCore/CompressedStorage.h
+++ b/Eigen/src/SparseCore/CompressedStorage.h
@@ -32,22 +32,26 @@ class CompressedStorage
 
   public:
 
+    EIGEN_DEVICE_FUNC
     CompressedStorage()
       : m_values(0), m_indices(0), m_size(0), m_allocatedSize(0)
     {}
 
+    EIGEN_DEVICE_FUNC
     explicit CompressedStorage(Index size)
       : m_values(0), m_indices(0), m_size(0), m_allocatedSize(0)
     {
       resize(size);
     }
 
+    EIGEN_DEVICE_FUNC
     CompressedStorage(const CompressedStorage& other)
       : m_values(0), m_indices(0), m_size(0), m_allocatedSize(0)
     {
       *this = other;
     }
 
+    EIGEN_DEVICE_FUNC
     CompressedStorage& operator=(const CompressedStorage& other)
     {
       resize(other.size());
@@ -59,20 +63,23 @@ class CompressedStorage
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     void swap(CompressedStorage& other)
     {
-      std::swap(m_values, other.m_values);
-      std::swap(m_indices, other.m_indices);
-      std::swap(m_size, other.m_size);
-      std::swap(m_allocatedSize, other.m_allocatedSize);
+      numext::swap(m_values, other.m_values);
+      numext::swap(m_indices, other.m_indices);
+      numext::swap(m_size, other.m_size);
+      numext::swap(m_allocatedSize, other.m_allocatedSize);
     }
 
+    EIGEN_DEVICE_FUNC
     ~CompressedStorage()
     {
       delete[] m_values;
       delete[] m_indices;
     }
 
+    EIGEN_DEVICE_FUNC
     void reserve(Index size)
     {
       Index newAllocatedSize = m_size + size;
@@ -80,12 +87,14 @@ class CompressedStorage
         reallocate(newAllocatedSize);
     }
 
+    EIGEN_DEVICE_FUNC
     void squeeze()
     {
       if (m_allocatedSize>m_size)
         reallocate(m_size);
     }
 
+    EIGEN_DEVICE_FUNC
     void resize(Index size, double reserveSizeFactor = 0)
     {
       if (m_allocatedSize<size)
@@ -98,6 +107,7 @@ class CompressedStorage
       m_size = size;
     }
 
+    EIGEN_DEVICE_FUNC
     void append(const Scalar& v, Index i)
     {
       Index id = m_size;
@@ -106,28 +116,41 @@ class CompressedStorage
       m_indices[id] = internal::convert_index<StorageIndex>(i);
     }
 
+    EIGEN_DEVICE_FUNC
     inline Index size() const { return m_size; }
+    EIGEN_DEVICE_FUNC
     inline Index allocatedSize() const { return m_allocatedSize; }
+    EIGEN_DEVICE_FUNC
     inline void clear() { m_size = 0; }
 
+    EIGEN_DEVICE_FUNC
     const Scalar* valuePtr() const { return m_values; }
+    EIGEN_DEVICE_FUNC
     Scalar* valuePtr() { return m_values; }
+    EIGEN_DEVICE_FUNC
     const StorageIndex* indexPtr() const { return m_indices; }
+    EIGEN_DEVICE_FUNC
     StorageIndex* indexPtr() { return m_indices; }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& value(Index i) { eigen_internal_assert(m_values!=0); return m_values[i]; }
+    EIGEN_DEVICE_FUNC
     inline const Scalar& value(Index i) const { eigen_internal_assert(m_values!=0); return m_values[i]; }
 
+    EIGEN_DEVICE_FUNC
     inline StorageIndex& index(Index i) { eigen_internal_assert(m_indices!=0); return m_indices[i]; }
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex& index(Index i) const { eigen_internal_assert(m_indices!=0); return m_indices[i]; }
 
     /** \returns the largest \c k such that for all \c j in [0,k) index[\c j]\<\a key */
+    EIGEN_DEVICE_FUNC
     inline Index searchLowerIndex(Index key) const
     {
       return searchLowerIndex(0, m_size, key);
     }
 
     /** \returns the largest \c k in [start,end) such that for all \c j in [start,k) index[\c j]\<\a key */
+    EIGEN_DEVICE_FUNC
     inline Index searchLowerIndex(Index start, Index end, Index key) const
     {
       while(end>start)
@@ -143,6 +166,7 @@ class CompressedStorage
 
     /** \returns the stored value at index \a key
       * If the value does not exist, then the value \a defaultValue is returned without any insertion. */
+    EIGEN_DEVICE_FUNC
     inline Scalar at(Index key, const Scalar& defaultValue = Scalar(0)) const
     {
       if (m_size==0)
@@ -156,6 +180,7 @@ class CompressedStorage
     }
 
     /** Like at(), but the search is performed in the range [start,end) */
+    EIGEN_DEVICE_FUNC
     inline Scalar atInRange(Index start, Index end, Index key, const Scalar &defaultValue = Scalar(0)) const
     {
       if (start>=end)
@@ -171,6 +196,7 @@ class CompressedStorage
     /** \returns a reference to the value at index \a key
       * If the value does not exist, then the value \a defaultValue is inserted
       * such that the keys are sorted. */
+    EIGEN_DEVICE_FUNC
     inline Scalar& atWithInsertion(Index key, const Scalar& defaultValue = Scalar(0))
     {
       Index id = searchLowerIndex(0,m_size,key);
@@ -192,8 +218,8 @@ class CompressedStorage
             internal::smart_copy(m_values +id,  m_values +m_size, newValues.ptr() +id+1);
             internal::smart_copy(m_indices+id,  m_indices+m_size, newIndices.ptr()+id+1);
           }
-          std::swap(m_values,newValues.ptr());
-          std::swap(m_indices,newIndices.ptr());
+          numext::swap(m_values,newValues.ptr());
+          numext::swap(m_indices,newIndices.ptr());
         }
         else if(m_size>id)
         {
@@ -207,6 +233,7 @@ class CompressedStorage
       return m_values[id];
     }
 
+    EIGEN_DEVICE_FUNC
     void moveChunk(Index from, Index to, Index chunkSize)
     {
       eigen_internal_assert(to+chunkSize <= m_size);
@@ -223,6 +250,7 @@ class CompressedStorage
       }
     }
 
+    EIGEN_DEVICE_FUNC
     void prune(const Scalar& reference, const RealScalar& epsilon = NumTraits<RealScalar>::dummy_precision())
     {
       Index k = 0;
@@ -241,6 +269,7 @@ class CompressedStorage
 
   protected:
 
+    EIGEN_DEVICE_FUNC
     inline void reallocate(Index size)
     {
       #ifdef EIGEN_SPARSE_COMPRESSED_STORAGE_REALLOCATE_PLUGIN
@@ -254,8 +283,8 @@ class CompressedStorage
         internal::smart_copy(m_values, m_values+copySize, newValues.ptr());
         internal::smart_copy(m_indices, m_indices+copySize, newIndices.ptr());
       }
-      std::swap(m_values,newValues.ptr());
-      std::swap(m_indices,newIndices.ptr());
+      numext::swap(m_values,newValues.ptr());
+      numext::swap(m_indices,newIndices.ptr());
       m_allocatedSize = size;
     }
 

--- a/Eigen/src/SparseCore/SparseAssign.h
+++ b/Eigen/src/SparseCore/SparseAssign.h
@@ -14,6 +14,7 @@ namespace Eigen {
 
 template<typename Derived>    
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 Derived& SparseMatrixBase<Derived>::operator=(const EigenBase<OtherDerived> &other)
 {
   internal::call_assignment_no_alias(derived(), other.derived());
@@ -22,6 +23,7 @@ Derived& SparseMatrixBase<Derived>::operator=(const EigenBase<OtherDerived> &oth
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 Derived& SparseMatrixBase<Derived>::operator=(const ReturnByValue<OtherDerived>& other)
 {
   // TODO use the evaluator mechanism
@@ -31,6 +33,7 @@ Derived& SparseMatrixBase<Derived>::operator=(const ReturnByValue<OtherDerived>&
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 inline Derived& SparseMatrixBase<Derived>::operator=(const SparseMatrixBase<OtherDerived>& other)
 {
   // by default sparse evaluation do not alias, so we can safely bypass the generic call_assignment routine
@@ -40,6 +43,7 @@ inline Derived& SparseMatrixBase<Derived>::operator=(const SparseMatrixBase<Othe
 }
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 inline Derived& SparseMatrixBase<Derived>::operator=(const Derived& other)
 {
   internal::call_assignment_no_alias(derived(), other.derived());
@@ -68,6 +72,7 @@ template<> struct AssignmentKind<DenseShape,  SparseTriangularShape> { typedef S
 
 
 template<typename DstXprType, typename SrcXprType>
+EIGEN_DEVICE_FUNC
 void assign_sparse_to_sparse(DstXprType &dst, const SrcXprType &src)
 {
   typedef typename DstXprType::Scalar Scalar;
@@ -127,6 +132,7 @@ void assign_sparse_to_sparse(DstXprType &dst, const SrcXprType &src)
 template< typename DstXprType, typename SrcXprType, typename Functor>
 struct Assignment<DstXprType, SrcXprType, Functor, Sparse2Sparse>
 {
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   {
     assign_sparse_to_sparse(dst.derived(), src.derived());
@@ -137,6 +143,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, Sparse2Sparse>
 template< typename DstXprType, typename SrcXprType, typename Functor, typename Weak>
 struct Assignment<DstXprType, SrcXprType, Functor, Sparse2Dense, Weak>
 {
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const Functor &func)
   {
     if(internal::is_same<Functor,internal::assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> >::value)
@@ -226,6 +233,7 @@ template<typename DstXprType, typename DecType, typename RhsType, typename Scala
 struct Assignment<DstXprType, Solve<DecType,RhsType>, internal::assign_op<Scalar,Scalar>, Sparse2Sparse>
 {
   typedef Solve<DecType,RhsType> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &)
   {
     Index dstRows = src.rows();
@@ -248,18 +256,22 @@ struct Assignment<DstXprType, SrcXprType, Functor, Diagonal2Sparse>
   typedef typename DstXprType::Scalar Scalar;
 
   template<int Options, typename AssignFunc>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrix<Scalar,Options,StorageIndex> &dst, const SrcXprType &src, const AssignFunc &func)
   { dst.assignDiagonal(src.diagonal(), func); }
   
   template<typename DstDerived>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrixBase<DstDerived> &dst, const SrcXprType &src, const internal::assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   { dst.derived().diagonal() = src.diagonal(); }
   
   template<typename DstDerived>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrixBase<DstDerived> &dst, const SrcXprType &src, const internal::add_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   { dst.derived().diagonal() += src.diagonal(); }
   
   template<typename DstDerived>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrixBase<DstDerived> &dst, const SrcXprType &src, const internal::sub_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &/*func*/)
   { dst.derived().diagonal() -= src.diagonal(); }
 };

--- a/Eigen/src/SparseCore/SparseBlock.h
+++ b/Eigen/src/SparseCore/SparseBlock.h
@@ -28,17 +28,22 @@ protected:
 public:
     EIGEN_SPARSE_PUBLIC_INTERFACE(BlockType)
 
+    EIGEN_DEVICE_FUNC
     inline BlockImpl(XprType& xpr, Index i)
       : m_matrix(xpr), m_outerStart(convert_index(i)), m_outerSize(OuterSize)
     {}
 
+    EIGEN_DEVICE_FUNC
     inline BlockImpl(XprType& xpr, Index startRow, Index startCol, Index blockRows, Index blockCols)
       : m_matrix(xpr), m_outerStart(convert_index(IsRowMajor ? startRow : startCol)), m_outerSize(convert_index(IsRowMajor ? blockRows : blockCols))
     {}
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index rows() const { return IsRowMajor ? m_outerSize.value() : m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index cols() const { return IsRowMajor ? m_matrix.cols() : m_outerSize.value(); }
 
+    EIGEN_DEVICE_FUNC
     Index nonZeros() const
     {
       typedef internal::evaluator<XprType> EvaluatorType;
@@ -51,21 +56,29 @@ public:
       return nnz;
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar coeff(Index row, Index col) const
     {
       return m_matrix.coeff(row + (IsRowMajor ? m_outerStart : 0), col + (IsRowMajor ? 0 :  m_outerStart));
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar coeff(Index index) const
     {
       return m_matrix.coeff(IsRowMajor ? m_outerStart : index, IsRowMajor ? index :  m_outerStart);
     }
 
+    EIGEN_DEVICE_FUNC
     inline const XprType& nestedExpression() const { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     inline XprType& nestedExpression() { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     Index startRow() const { return IsRowMajor ? m_outerStart : 0; }
+    EIGEN_DEVICE_FUNC
     Index startCol() const { return IsRowMajor ? 0 : m_outerStart; }
+    EIGEN_DEVICE_FUNC
     Index blockRows() const { return IsRowMajor ? m_outerSize.value() : m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
     Index blockCols() const { return IsRowMajor ? m_matrix.cols() : m_outerSize.value(); }
 
   protected:
@@ -78,6 +91,7 @@ public:
     // Disable assignment with clear error message.
     // Note that simply removing operator= yields compilation errors with ICC+MSVC
     template<typename T>
+    EIGEN_DEVICE_FUNC
     BlockImpl& operator=(const T&)
     {
       EIGEN_STATIC_ASSERT(sizeof(T)==0, THIS_SPARSE_BLOCK_SUBEXPRESSION_IS_READ_ONLY);
@@ -108,15 +122,18 @@ protected:
     enum { OuterSize = IsRowMajor ? BlockRows : BlockCols };
 public:
 
+    EIGEN_DEVICE_FUNC
     inline sparse_matrix_block_impl(SparseMatrixType& xpr, Index i)
       : m_matrix(xpr), m_outerStart(convert_index(i)), m_outerSize(OuterSize)
     {}
 
+    EIGEN_DEVICE_FUNC
     inline sparse_matrix_block_impl(SparseMatrixType& xpr, Index startRow, Index startCol, Index blockRows, Index blockCols)
       : m_matrix(xpr), m_outerStart(convert_index(IsRowMajor ? startRow : startCol)), m_outerSize(convert_index(IsRowMajor ? blockRows : blockCols))
     {}
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline BlockType& operator=(const SparseMatrixBase<OtherDerived>& other)
     {
       typedef typename internal::remove_all<typename SparseMatrixType::Nested>::type _NestedMatrixType;
@@ -211,48 +228,62 @@ public:
       return derived();
     }
 
+    EIGEN_DEVICE_FUNC
     inline BlockType& operator=(const BlockType& other)
     {
       return operator=<BlockType>(other);
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar* valuePtr() const
     { return m_matrix.valuePtr(); }
+    EIGEN_DEVICE_FUNC
     inline Scalar* valuePtr()
     { return m_matrix.valuePtr(); }
 
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerIndexPtr() const
     { return m_matrix.innerIndexPtr(); }
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerIndexPtr()
     { return m_matrix.innerIndexPtr(); }
 
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* outerIndexPtr() const
     { return m_matrix.outerIndexPtr() + m_outerStart; }
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* outerIndexPtr()
     { return m_matrix.outerIndexPtr() + m_outerStart; }
 
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerNonZeroPtr() const
     { return isCompressed() ? 0 : (m_matrix.innerNonZeroPtr()+m_outerStart); }
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerNonZeroPtr()
     { return isCompressed() ? 0 : (m_matrix.innerNonZeroPtr()+m_outerStart); }
 
+    EIGEN_DEVICE_FUNC
     bool isCompressed() const { return m_matrix.innerNonZeroPtr()==0; }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& coeffRef(Index row, Index col)
     {
       return m_matrix.coeffRef(row + (IsRowMajor ? m_outerStart : 0), col + (IsRowMajor ? 0 :  m_outerStart));
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar coeff(Index row, Index col) const
     {
       return m_matrix.coeff(row + (IsRowMajor ? m_outerStart : 0), col + (IsRowMajor ? 0 :  m_outerStart));
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar coeff(Index index) const
     {
       return m_matrix.coeff(IsRowMajor ? m_outerStart : index, IsRowMajor ? index :  m_outerStart);
     }
 
+    EIGEN_DEVICE_FUNC
     const Scalar& lastCoeff() const
     {
       EIGEN_STATIC_ASSERT_VECTOR_ONLY(sparse_matrix_block_impl);
@@ -263,14 +294,22 @@ public:
         return m_matrix.valuePtr()[m_matrix.outerIndexPtr()[m_outerStart]+m_matrix.innerNonZeroPtr()[m_outerStart]-1];
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index rows() const { return IsRowMajor ? m_outerSize.value() : m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index cols() const { return IsRowMajor ? m_matrix.cols() : m_outerSize.value(); }
 
+    EIGEN_DEVICE_FUNC
     inline const SparseMatrixType& nestedExpression() const { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     inline SparseMatrixType& nestedExpression() { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     Index startRow() const { return IsRowMajor ? m_outerStart : 0; }
+    EIGEN_DEVICE_FUNC
     Index startCol() const { return IsRowMajor ? 0 : m_outerStart; }
+    EIGEN_DEVICE_FUNC
     Index blockRows() const { return IsRowMajor ? m_outerSize.value() : m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
     Index blockCols() const { return IsRowMajor ? m_matrix.cols() : m_outerSize.value(); }
 
   protected:
@@ -291,10 +330,12 @@ public:
   typedef _StorageIndex StorageIndex;
   typedef SparseMatrix<_Scalar, _Options, _StorageIndex> SparseMatrixType;
   typedef internal::sparse_matrix_block_impl<SparseMatrixType,BlockRows,BlockCols> Base;
+  EIGEN_DEVICE_FUNC
   inline BlockImpl(SparseMatrixType& xpr, Index i)
     : Base(xpr, i)
   {}
 
+  EIGEN_DEVICE_FUNC
   inline BlockImpl(SparseMatrixType& xpr, Index startRow, Index startCol, Index blockRows, Index blockCols)
     : Base(xpr, startRow, startCol, blockRows, blockCols)
   {}
@@ -310,10 +351,12 @@ public:
   typedef _StorageIndex StorageIndex;
   typedef const SparseMatrix<_Scalar, _Options, _StorageIndex> SparseMatrixType;
   typedef internal::sparse_matrix_block_impl<SparseMatrixType,BlockRows,BlockCols> Base;
+  EIGEN_DEVICE_FUNC
   inline BlockImpl(SparseMatrixType& xpr, Index i)
     : Base(xpr, i)
   {}
 
+  EIGEN_DEVICE_FUNC
   inline BlockImpl(SparseMatrixType& xpr, Index startRow, Index startCol, Index blockRows, Index blockCols)
     : Base(xpr, startRow, startCol, blockRows, blockCols)
   {}
@@ -344,6 +387,7 @@ public:
 
     /** Column or Row constructor
       */
+    EIGEN_DEVICE_FUNC
     inline BlockImpl(XprType& xpr, Index i)
       : m_matrix(xpr),
         m_startRow( (BlockRows==1) && (BlockCols==XprType::ColsAtCompileTime) ? convert_index(i) : 0),
@@ -354,46 +398,60 @@ public:
 
     /** Dynamic-size constructor
       */
+    EIGEN_DEVICE_FUNC
     inline BlockImpl(XprType& xpr, Index startRow, Index startCol, Index blockRows, Index blockCols)
       : m_matrix(xpr), m_startRow(convert_index(startRow)), m_startCol(convert_index(startCol)), m_blockRows(convert_index(blockRows)), m_blockCols(convert_index(blockCols))
     {}
 
+    EIGEN_DEVICE_FUNC
     inline Index rows() const { return m_blockRows.value(); }
+    EIGEN_DEVICE_FUNC
     inline Index cols() const { return m_blockCols.value(); }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& coeffRef(Index row, Index col)
     {
       return m_matrix.coeffRef(row + m_startRow.value(), col + m_startCol.value());
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar coeff(Index row, Index col) const
     {
       return m_matrix.coeff(row + m_startRow.value(), col + m_startCol.value());
     }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& coeffRef(Index index)
     {
       return m_matrix.coeffRef(m_startRow.value() + (RowsAtCompileTime == 1 ? 0 : index),
                                m_startCol.value() + (RowsAtCompileTime == 1 ? index : 0));
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar coeff(Index index) const
     {
       return m_matrix.coeff(m_startRow.value() + (RowsAtCompileTime == 1 ? 0 : index),
                             m_startCol.value() + (RowsAtCompileTime == 1 ? index : 0));
     }
 
+    EIGEN_DEVICE_FUNC
     inline const XprType& nestedExpression() const { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     inline XprType& nestedExpression() { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     Index startRow() const { return m_startRow.value(); }
+    EIGEN_DEVICE_FUNC
     Index startCol() const { return m_startCol.value(); }
+    EIGEN_DEVICE_FUNC
     Index blockRows() const { return m_blockRows.value(); }
+    EIGEN_DEVICE_FUNC
     Index blockCols() const { return m_blockCols.value(); }
 
   protected:
 //     friend class internal::GenericSparseBlockInnerIteratorImpl<XprType,BlockRows,BlockCols,InnerPanel>;
     friend struct internal::unary_evaluator<Block<XprType,BlockRows,BlockCols,InnerPanel>, internal::IteratorBased, Scalar >;
 
+    EIGEN_DEVICE_FUNC
     Index nonZeros() const { return Dynamic; }
 
     typename internal::ref_selector<XprType>::non_const_type m_matrix;
@@ -406,6 +464,7 @@ public:
     // Disable assignment with clear error message.
     // Note that simply removing operator= yields compilation errors with ICC+MSVC
     template<typename T>
+    EIGEN_DEVICE_FUNC
     BlockImpl& operator=(const T&)
     {
       EIGEN_STATIC_ASSERT(sizeof(T)==0, THIS_SPARSE_BLOCK_SUBEXPRESSION_IS_READ_ONLY);
@@ -441,10 +500,12 @@ struct unary_evaluator<Block<ArgType,BlockRows,BlockCols,InnerPanel>, IteratorBa
 
     typedef typename internal::conditional<OuterVector,OuterVectorInnerIterator,InnerVectorInnerIterator>::type InnerIterator;
 
+    EIGEN_DEVICE_FUNC
     explicit unary_evaluator(const XprType& op)
       : m_argImpl(op.nestedExpression()), m_block(op)
     {}
 
+    EIGEN_DEVICE_FUNC
     inline Index nonZerosEstimate() const {
       const Index nnz = m_block.nonZeros();
       if(nnz < 0) {
@@ -475,6 +536,7 @@ class unary_evaluator<Block<ArgType,BlockRows,BlockCols,InnerPanel>, IteratorBas
   Index m_end;
 public:
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE InnerVectorInnerIterator(const unary_evaluator& aEval, Index outer)
     : EvalIterator(aEval.m_argImpl, outer + (XprIsRowMajor ? aEval.m_block.startRow() : aEval.m_block.startCol())),
       m_block(aEval.m_block),
@@ -484,11 +546,16 @@ public:
       EvalIterator::operator++();
   }
 
+  EIGEN_DEVICE_FUNC
   inline StorageIndex index() const { return EvalIterator::index() - convert_index<StorageIndex>(XprIsRowMajor ? m_block.startCol() : m_block.startRow()); }
+  EIGEN_DEVICE_FUNC
   inline Index outer()  const { return EvalIterator::outer() - (XprIsRowMajor ? m_block.startRow() : m_block.startCol()); }
+  EIGEN_DEVICE_FUNC
   inline Index row()    const { return EvalIterator::row()   - m_block.startRow(); }
+  EIGEN_DEVICE_FUNC
   inline Index col()    const { return EvalIterator::col()   - m_block.startCol(); }
 
+  EIGEN_DEVICE_FUNC
   inline operator bool() const { return EvalIterator::operator bool() && EvalIterator::index() < m_end; }
 };
 
@@ -504,6 +571,7 @@ class unary_evaluator<Block<ArgType,BlockRows,BlockCols,InnerPanel>, IteratorBas
   EvalIterator m_it;
 public:
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE OuterVectorInnerIterator(const unary_evaluator& aEval, Index outer)
     : m_eval(aEval),
       m_outerPos( (XprIsRowMajor ? aEval.m_block.startCol() : aEval.m_block.startRow()) ),
@@ -519,14 +587,21 @@ public:
       ++(*this);
   }
 
+  EIGEN_DEVICE_FUNC
   inline StorageIndex index() const { return convert_index<StorageIndex>(m_outerPos - (XprIsRowMajor ? m_eval.m_block.startCol() : m_eval.m_block.startRow())); }
+  EIGEN_DEVICE_FUNC
   inline Index outer()  const { return 0; }
+  EIGEN_DEVICE_FUNC
   inline Index row()    const { return XprIsRowMajor ? 0 : index(); }
+  EIGEN_DEVICE_FUNC
   inline Index col()    const { return XprIsRowMajor ? index() : 0; }
 
+  EIGEN_DEVICE_FUNC
   inline Scalar value() const { return m_it.value(); }
+  EIGEN_DEVICE_FUNC
   inline Scalar& valueRef() { return m_it.valueRef(); }
 
+  EIGEN_DEVICE_FUNC
   inline OuterVectorInnerIterator& operator++()
   {
     // search next non-zero entry
@@ -542,6 +617,7 @@ public:
     return *this;
   }
 
+  EIGEN_DEVICE_FUNC
   inline operator bool() const { return m_outerPos < m_end; }
 };
 
@@ -551,6 +627,7 @@ struct unary_evaluator<Block<SparseMatrix<_Scalar, _Options, _StorageIndex>,Bloc
 {
   typedef Block<SparseMatrix<_Scalar, _Options, _StorageIndex>,BlockRows,BlockCols,true> XprType;
   typedef evaluator<SparseCompressedBase<XprType> > Base;
+  EIGEN_DEVICE_FUNC
   explicit unary_evaluator(const XprType &xpr) : Base(xpr) {}
 };
 
@@ -560,6 +637,7 @@ struct unary_evaluator<Block<const SparseMatrix<_Scalar, _Options, _StorageIndex
 {
   typedef Block<const SparseMatrix<_Scalar, _Options, _StorageIndex>,BlockRows,BlockCols,true> XprType;
   typedef evaluator<SparseCompressedBase<XprType> > Base;
+  EIGEN_DEVICE_FUNC
   explicit unary_evaluator(const XprType &xpr) : Base(xpr) {}
 };
 

--- a/Eigen/src/SparseCore/SparseColEtree.h
+++ b/Eigen/src/SparseCore/SparseColEtree.h
@@ -37,6 +37,7 @@ namespace internal {
 
 /** Find the root of the tree/set containing the vertex i : Use Path halving */ 
 template<typename Index, typename IndexVector>
+EIGEN_DEVICE_FUNC
 Index etree_find (Index i, IndexVector& pp)
 {
   Index p = pp(i); // Parent 
@@ -58,6 +59,7 @@ Index etree_find (Index i, IndexVector& pp)
   * \param perm The permutation to apply to the column of \b mat
   */
 template <typename MatrixType, typename IndexVector>
+EIGEN_DEVICE_FUNC
 int coletree(const MatrixType& mat, IndexVector& parent, IndexVector& firstRowElt, typename MatrixType::StorageIndex *perm=0)
 {
   typedef typename MatrixType::StorageIndex StorageIndex;
@@ -127,6 +129,7 @@ int coletree(const MatrixType& mat, IndexVector& parent, IndexVector& firstRowEl
   * This routine was contributed by Cédric Doucet, CEDRAT Group, Meylan, France.
 */
 template <typename IndexVector>
+EIGEN_DEVICE_FUNC
 void nr_etdfs (typename IndexVector::Scalar n, IndexVector& parent, IndexVector& first_kid, IndexVector& next_kid, IndexVector& post, typename IndexVector::Scalar postnum)
 {
   typedef typename IndexVector::Scalar StorageIndex;
@@ -175,6 +178,7 @@ void nr_etdfs (typename IndexVector::Scalar n, IndexVector& parent, IndexVector&
   * \param post postordered tree
   */
 template <typename IndexVector>
+EIGEN_DEVICE_FUNC
 void treePostorder(typename IndexVector::Scalar n, IndexVector& parent, IndexVector& post)
 {
   typedef typename IndexVector::Scalar StorageIndex;

--- a/Eigen/src/SparseCore/SparseCompressedBase.h
+++ b/Eigen/src/SparseCore/SparseCompressedBase.h
@@ -47,12 +47,15 @@ class SparseCompressedBase
     
   protected:
     typedef typename Base::IndexVector IndexVector;
+    EIGEN_DEVICE_FUNC
     Eigen::Map<IndexVector> innerNonZeros() { return Eigen::Map<IndexVector>(innerNonZeroPtr(), isCompressed()?0:derived().outerSize()); }
+    EIGEN_DEVICE_FUNC
     const  Eigen::Map<const IndexVector> innerNonZeros() const { return Eigen::Map<const IndexVector>(innerNonZeroPtr(), isCompressed()?0:derived().outerSize()); }
         
   public:
     
     /** \returns the number of non zero coefficients */
+    EIGEN_DEVICE_FUNC
     inline Index nonZeros() const
     {
       if(Derived::IsVectorAtCompileTime && outerIndexPtr()==0)
@@ -68,42 +71,51 @@ class SparseCompressedBase
     /** \returns a const pointer to the array of values.
       * This function is aimed at interoperability with other libraries.
       * \sa innerIndexPtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline const Scalar* valuePtr() const { return derived().valuePtr(); }
     /** \returns a non-const pointer to the array of values.
       * This function is aimed at interoperability with other libraries.
       * \sa innerIndexPtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline Scalar* valuePtr() { return derived().valuePtr(); }
 
     /** \returns a const pointer to the array of inner indices.
       * This function is aimed at interoperability with other libraries.
       * \sa valuePtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerIndexPtr() const { return derived().innerIndexPtr(); }
     /** \returns a non-const pointer to the array of inner indices.
       * This function is aimed at interoperability with other libraries.
       * \sa valuePtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerIndexPtr() { return derived().innerIndexPtr(); }
 
     /** \returns a const pointer to the array of the starting positions of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \warning it returns the null pointer 0 for SparseVector
       * \sa valuePtr(), innerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* outerIndexPtr() const { return derived().outerIndexPtr(); }
     /** \returns a non-const pointer to the array of the starting positions of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \warning it returns the null pointer 0 for SparseVector
       * \sa valuePtr(), innerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* outerIndexPtr() { return derived().outerIndexPtr(); }
 
     /** \returns a const pointer to the array of the number of non zeros of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \warning it returns the null pointer 0 in compressed mode */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerNonZeroPtr() const { return derived().innerNonZeroPtr(); }
     /** \returns a non-const pointer to the array of the number of non zeros of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \warning it returns the null pointer 0 in compressed mode */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerNonZeroPtr() { return derived().innerNonZeroPtr(); }
     
     /** \returns whether \c *this is in compressed form. */
+    EIGEN_DEVICE_FUNC
     inline bool isCompressed() const { return innerNonZeroPtr()==0; }
 
     /** \returns a read-only view of the stored coefficients as a 1D array expression.
@@ -111,6 +123,7 @@ class SparseCompressedBase
       * \warning this method is for \b compressed \b storage \b only, and it will trigger an assertion otherwise.
       *
       * \sa valuePtr(), isCompressed() */
+    EIGEN_DEVICE_FUNC
     const Map<const Array<Scalar,Dynamic,1> > coeffs() const { eigen_assert(isCompressed()); return Array<Scalar,Dynamic,1>::Map(valuePtr(),nonZeros()); }
 
     /** \returns a read-write view of the stored coefficients as a 1D array expression
@@ -123,10 +136,12 @@ class SparseCompressedBase
       * \include SparseMatrix_coeffs.out
       *
       * \sa valuePtr(), isCompressed() */
+    EIGEN_DEVICE_FUNC
     Map<Array<Scalar,Dynamic,1> > coeffs() { eigen_assert(isCompressed()); return Array<Scalar,Dynamic,1>::Map(valuePtr(),nonZeros()); }
 
   protected:
     /** Default constructor. Do nothing. */
+    EIGEN_DEVICE_FUNC
     SparseCompressedBase() {}
 
     /** \internal return the index of the coeff at (row,col) or just before if it does not exist.
@@ -151,21 +166,25 @@ class SparseCompressedBase
     friend struct internal::evaluator<SparseCompressedBase<Derived> >;
 
   private:
-    template<typename OtherDerived> explicit SparseCompressedBase(const SparseCompressedBase<OtherDerived>&);
+    template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
+    explicit SparseCompressedBase(const SparseCompressedBase<OtherDerived>&);
 };
 
 template<typename Derived>
 class SparseCompressedBase<Derived>::InnerIterator
 {
   public:
-    InnerIterator()
+    EIGEN_DEVICE_FUNC InnerIterator()
       : m_values(0), m_indices(0), m_outer(0), m_id(0), m_end(0)
     {}
 
+    EIGEN_DEVICE_FUNC
     InnerIterator(const InnerIterator& other)
       : m_values(other.m_values), m_indices(other.m_indices), m_outer(other.m_outer), m_id(other.m_id), m_end(other.m_end)
     {}
 
+    EIGEN_DEVICE_FUNC
     InnerIterator& operator=(const InnerIterator& other)
     {
       m_values = other.m_values;
@@ -176,6 +195,7 @@ class SparseCompressedBase<Derived>::InnerIterator
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     InnerIterator(const SparseCompressedBase& mat, Index outer)
       : m_values(mat.valuePtr()), m_indices(mat.innerIndexPtr()), m_outer(outer)
     {
@@ -194,21 +214,26 @@ class SparseCompressedBase<Derived>::InnerIterator
       }
     }
 
+    EIGEN_DEVICE_FUNC
     explicit InnerIterator(const SparseCompressedBase& mat)
       : m_values(mat.valuePtr()), m_indices(mat.innerIndexPtr()), m_outer(0), m_id(0), m_end(mat.nonZeros())
     {
       EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived);
     }
 
+    EIGEN_DEVICE_FUNC
     explicit InnerIterator(const internal::CompressedStorage<Scalar,StorageIndex>& data)
       : m_values(data.valuePtr()), m_indices(data.indexPtr()), m_outer(0), m_id(0), m_end(data.size())
     {
       EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived);
     }
 
+    EIGEN_DEVICE_FUNC
     inline InnerIterator& operator++() { m_id++; return *this; }
+    EIGEN_DEVICE_FUNC
     inline InnerIterator& operator+=(Index i) { m_id += i ; return *this; }
 
+    EIGEN_DEVICE_FUNC
     inline InnerIterator operator+(Index i) 
     { 
         InnerIterator result = *this;
@@ -216,14 +241,21 @@ class SparseCompressedBase<Derived>::InnerIterator
         return result;
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar& value() const { return m_values[m_id]; }
+    EIGEN_DEVICE_FUNC
     inline Scalar& valueRef() { return const_cast<Scalar&>(m_values[m_id]); }
 
+    EIGEN_DEVICE_FUNC
     inline StorageIndex index() const { return m_indices[m_id]; }
+    EIGEN_DEVICE_FUNC
     inline Index outer() const { return m_outer.value(); }
+    EIGEN_DEVICE_FUNC
     inline Index row() const { return IsRowMajor ? m_outer.value() : index(); }
+    EIGEN_DEVICE_FUNC
     inline Index col() const { return IsRowMajor ? index() : m_outer.value(); }
 
+    EIGEN_DEVICE_FUNC
     inline operator bool() const { return (m_id < m_end); }
 
   protected:
@@ -237,13 +269,16 @@ class SparseCompressedBase<Derived>::InnerIterator
     // If you get here, then you're not using the right InnerIterator type, e.g.:
     //   SparseMatrix<double,RowMajor> A;
     //   SparseMatrix<double>::InnerIterator it(A,0);
-    template<typename T> InnerIterator(const SparseMatrixBase<T>&, Index outer);
+    template<typename T>
+    EIGEN_DEVICE_FUNC
+    InnerIterator(const SparseMatrixBase<T>&, Index outer);
 };
 
 template<typename Derived>
 class SparseCompressedBase<Derived>::ReverseInnerIterator
 {
   public:
+    EIGEN_DEVICE_FUNC
     ReverseInnerIterator(const SparseCompressedBase& mat, Index outer)
       : m_values(mat.valuePtr()), m_indices(mat.innerIndexPtr()), m_outer(outer)
     {
@@ -262,21 +297,26 @@ class SparseCompressedBase<Derived>::ReverseInnerIterator
       }
     }
 
+    EIGEN_DEVICE_FUNC
     explicit ReverseInnerIterator(const SparseCompressedBase& mat)
       : m_values(mat.valuePtr()), m_indices(mat.innerIndexPtr()), m_outer(0), m_start(0), m_id(mat.nonZeros())
     {
       EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived);
     }
 
+    EIGEN_DEVICE_FUNC
     explicit ReverseInnerIterator(const internal::CompressedStorage<Scalar,StorageIndex>& data)
       : m_values(data.valuePtr()), m_indices(data.indexPtr()), m_outer(0), m_start(0), m_id(data.size())
     {
       EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived);
     }
 
+    EIGEN_DEVICE_FUNC
     inline ReverseInnerIterator& operator--() { --m_id; return *this; }
+    EIGEN_DEVICE_FUNC
     inline ReverseInnerIterator& operator-=(Index i) { m_id -= i; return *this; }
 
+    EIGEN_DEVICE_FUNC
     inline ReverseInnerIterator operator-(Index i) 
     {
         ReverseInnerIterator result = *this;
@@ -284,14 +324,21 @@ class SparseCompressedBase<Derived>::ReverseInnerIterator
         return result;
     }
 
+    EIGEN_DEVICE_FUNC
     inline const Scalar& value() const { return m_values[m_id-1]; }
+    EIGEN_DEVICE_FUNC
     inline Scalar& valueRef() { return const_cast<Scalar&>(m_values[m_id-1]); }
 
+    EIGEN_DEVICE_FUNC
     inline StorageIndex index() const { return m_indices[m_id-1]; }
+    EIGEN_DEVICE_FUNC
     inline Index outer() const { return m_outer.value(); }
+    EIGEN_DEVICE_FUNC
     inline Index row() const { return IsRowMajor ? m_outer.value() : index(); }
+    EIGEN_DEVICE_FUNC
     inline Index col() const { return IsRowMajor ? index() : m_outer.value(); }
 
+    EIGEN_DEVICE_FUNC
     inline operator bool() const { return (m_id > m_start); }
 
   protected:
@@ -317,23 +364,29 @@ struct evaluator<SparseCompressedBase<Derived> >
     Flags = Derived::Flags
   };
   
+  EIGEN_DEVICE_FUNC
   evaluator() : m_matrix(0), m_zero(0)
   {
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
+  EIGEN_DEVICE_FUNC
   explicit evaluator(const Derived &mat) : m_matrix(&mat), m_zero(0)
   {
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_matrix->nonZeros();
   }
   
+  EIGEN_DEVICE_FUNC
   operator Derived&() { return m_matrix->const_cast_derived(); }
+  EIGEN_DEVICE_FUNC
   operator const Derived&() const { return *m_matrix; }
   
   typedef typename DenseCoeffsBase<Derived,ReadOnlyAccessors>::CoeffReturnType CoeffReturnType;
+  EIGEN_DEVICE_FUNC
   const Scalar& coeff(Index row, Index col) const
   {
     Index p = find(row,col);
@@ -344,6 +397,7 @@ struct evaluator<SparseCompressedBase<Derived> >
       return m_matrix->const_cast_derived().valuePtr()[p];
   }
 
+  EIGEN_DEVICE_FUNC
   Scalar& coeffRef(Index row, Index col)
   {
     Index p = find(row,col);
@@ -353,6 +407,7 @@ struct evaluator<SparseCompressedBase<Derived> >
 
 protected:
 
+  EIGEN_DEVICE_FUNC
   Index find(Index row, Index col) const
   {
     internal::LowerBoundIndex p = m_matrix->lower_bound(row,col);

--- a/Eigen/src/SparseCore/SparseCwiseBinaryOp.h
+++ b/Eigen/src/SparseCore/SparseCwiseBinaryOp.h
@@ -40,6 +40,7 @@ class CwiseBinaryOpImpl<BinaryOp, Lhs, Rhs, Sparse>
     typedef CwiseBinaryOp<BinaryOp, Lhs, Rhs> Derived;
     typedef SparseMatrixBase<Derived> Base;
     EIGEN_SPARSE_PUBLIC_INTERFACE(Derived)
+    EIGEN_DEVICE_FUNC
     CwiseBinaryOpImpl()
     {
       EIGEN_STATIC_ASSERT((
@@ -72,12 +73,14 @@ public:
   {
   public:
     
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const binary_evaluator& aEval, Index outer)
       : m_lhsIter(aEval.m_lhsImpl,outer), m_rhsIter(aEval.m_rhsImpl,outer), m_functor(aEval.m_functor)
     {
       this->operator++();
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     {
       if (m_lhsIter && m_rhsIter && (m_lhsIter.index() == m_rhsIter.index()))
@@ -107,13 +110,19 @@ public:
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const { return m_value; }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex index() const { return m_id; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outer() const { return m_lhsIter.outer(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index row() const { return Lhs::IsRowMajor ? m_lhsIter.row() : index(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index col() const { return Lhs::IsRowMajor ? index() : m_lhsIter.col(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE operator bool() const { return m_id>=0; }
 
   protected:
@@ -130,6 +139,7 @@ public:
     Flags = XprType::Flags
   };
   
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr)
     : m_functor(xpr.functor()),
       m_lhsImpl(xpr.lhs()), 
@@ -139,6 +149,7 @@ public:
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_lhsImpl.nonZerosEstimate() + m_rhsImpl.nonZerosEstimate();
   }
@@ -166,12 +177,14 @@ public:
     enum { IsRowMajor = (int(Rhs::Flags)&RowMajorBit)==RowMajorBit };
   public:
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const binary_evaluator& aEval, Index outer)
       : m_lhsEval(aEval.m_lhsImpl), m_rhsIter(aEval.m_rhsImpl,outer), m_functor(aEval.m_functor), m_value(0), m_id(-1), m_innerSize(aEval.m_expr.rhs().innerSize())
     {
       this->operator++();
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     {
       ++m_id;
@@ -191,13 +204,19 @@ public:
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const { eigen_internal_assert(m_id<m_innerSize); return m_value; }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex index() const { return m_id; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outer() const { return m_rhsIter.outer(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index row() const { return IsRowMajor ? m_rhsIter.outer() : m_id; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index col() const { return IsRowMajor ? m_id : m_rhsIter.outer(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE operator bool() const { return m_id<m_innerSize; }
 
   protected:
@@ -215,6 +234,7 @@ public:
     Flags = XprType::Flags
   };
 
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr)
     : m_functor(xpr.functor()),
       m_lhsImpl(xpr.lhs()),
@@ -225,6 +245,7 @@ public:
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
 
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_expr.size();
   }
@@ -253,12 +274,14 @@ public:
     enum { IsRowMajor = (int(Lhs::Flags)&RowMajorBit)==RowMajorBit };
   public:
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const binary_evaluator& aEval, Index outer)
       : m_lhsIter(aEval.m_lhsImpl,outer), m_rhsEval(aEval.m_rhsImpl), m_functor(aEval.m_functor), m_value(0), m_id(-1), m_innerSize(aEval.m_expr.lhs().innerSize())
     {
       this->operator++();
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     {
       ++m_id;
@@ -278,13 +301,19 @@ public:
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const { eigen_internal_assert(m_id<m_innerSize); return m_value; }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex index() const { return m_id; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outer() const { return m_lhsIter.outer(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index row() const { return IsRowMajor ? m_lhsIter.outer() : m_id; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index col() const { return IsRowMajor ? m_id : m_lhsIter.outer(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE operator bool() const { return m_id<m_innerSize; }
 
   protected:
@@ -302,6 +331,7 @@ public:
     Flags = XprType::Flags
   };
 
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr)
     : m_functor(xpr.functor()),
       m_lhsImpl(xpr.lhs()),
@@ -312,6 +342,7 @@ public:
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
 
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_expr.size();
   }
@@ -336,6 +367,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_product_op<T1,T2>, Lhs, Rhs>, Itera
 {
   typedef CwiseBinaryOp<scalar_product_op<T1,T2>, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 // "dense .* sparse"
@@ -345,6 +377,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_product_op<T1,T2>, Lhs, Rhs>, Index
 {
   typedef CwiseBinaryOp<scalar_product_op<T1,T2>, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 // "sparse .* dense"
@@ -354,6 +387,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_product_op<T1,T2>, Lhs, Rhs>, Itera
 {
   typedef CwiseBinaryOp<scalar_product_op<T1,T2>, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 
@@ -364,6 +398,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_quotient_op<T1,T2>, Lhs, Rhs>, Iter
 {
   typedef CwiseBinaryOp<scalar_quotient_op<T1,T2>, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 
@@ -374,6 +409,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_boolean_and_op, Lhs, Rhs>, Iterator
 {
   typedef CwiseBinaryOp<scalar_boolean_and_op, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 // "dense && sparse"
@@ -383,6 +419,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_boolean_and_op, Lhs, Rhs>, IndexBas
 {
   typedef CwiseBinaryOp<scalar_boolean_and_op, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 // "sparse && dense"
@@ -392,6 +429,7 @@ struct binary_evaluator<CwiseBinaryOp<scalar_boolean_and_op, Lhs, Rhs>, Iterator
 {
   typedef CwiseBinaryOp<scalar_boolean_and_op, Lhs, Rhs> XprType;
   typedef sparse_conjunction_evaluator<XprType> Base;
+  EIGEN_DEVICE_FUNC
   explicit binary_evaluator(const XprType& xpr) : Base(xpr) {}
 };
 
@@ -414,6 +452,7 @@ public:
   {
   public:
     
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const sparse_conjunction_evaluator& aEval, Index outer)
       : m_lhsIter(aEval.m_lhsImpl,outer), m_rhsIter(aEval.m_rhsImpl,outer), m_functor(aEval.m_functor)
     {
@@ -426,6 +465,7 @@ public:
       }
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     {
       ++m_lhsIter;
@@ -440,13 +480,19 @@ public:
       return *this;
     }
     
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const { return m_functor(m_lhsIter.value(), m_rhsIter.value()); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex index() const { return m_lhsIter.index(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outer() const { return m_lhsIter.outer(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index row() const { return m_lhsIter.row(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index col() const { return m_lhsIter.col(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE operator bool() const { return (m_lhsIter && m_rhsIter); }
 
   protected:
@@ -461,6 +507,7 @@ public:
     Flags = XprType::Flags
   };
   
+  EIGEN_DEVICE_FUNC
   explicit sparse_conjunction_evaluator(const XprType& xpr)
     : m_functor(xpr.functor()),
       m_lhsImpl(xpr.lhs()), 
@@ -470,6 +517,7 @@ public:
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return (std::min)(m_lhsImpl.nonZerosEstimate(), m_rhsImpl.nonZerosEstimate());
   }
@@ -501,24 +549,32 @@ public:
 
   public:
     
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const sparse_conjunction_evaluator& aEval, Index outer)
       : m_lhsEval(aEval.m_lhsImpl), m_rhsIter(aEval.m_rhsImpl,outer), m_functor(aEval.m_functor), m_outer(outer)
     {}
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     {
       ++m_rhsIter;
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const
     { return m_functor(m_lhsEval.coeff(IsRowMajor?m_outer:m_rhsIter.index(),IsRowMajor?m_rhsIter.index():m_outer), m_rhsIter.value()); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex index() const { return m_rhsIter.index(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outer() const { return m_rhsIter.outer(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index row() const { return m_rhsIter.row(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index col() const { return m_rhsIter.col(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE operator bool() const { return m_rhsIter; }
     
   protected:
@@ -534,6 +590,7 @@ public:
     Flags = XprType::Flags
   };
   
+  EIGEN_DEVICE_FUNC
   explicit sparse_conjunction_evaluator(const XprType& xpr)
     : m_functor(xpr.functor()),
       m_lhsImpl(xpr.lhs()), 
@@ -543,6 +600,7 @@ public:
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_rhsImpl.nonZerosEstimate();
   }
@@ -573,26 +631,34 @@ public:
     enum { IsRowMajor = (int(LhsArg::Flags)&RowMajorBit)==RowMajorBit };
 
   public:
-    
+
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const sparse_conjunction_evaluator& aEval, Index outer)
       : m_lhsIter(aEval.m_lhsImpl,outer), m_rhsEval(aEval.m_rhsImpl), m_functor(aEval.m_functor), m_outer(outer)
     {}
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     {
       ++m_lhsIter;
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const
     { return m_functor(m_lhsIter.value(),
                        m_rhsEval.coeff(IsRowMajor?m_outer:m_lhsIter.index(),IsRowMajor?m_lhsIter.index():m_outer)); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex index() const { return m_lhsIter.index(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outer() const { return m_lhsIter.outer(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index row() const { return m_lhsIter.row(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index col() const { return m_lhsIter.col(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE operator bool() const { return m_lhsIter; }
     
   protected:
@@ -608,6 +674,7 @@ public:
     Flags = XprType::Flags
   };
   
+  EIGEN_DEVICE_FUNC
   explicit sparse_conjunction_evaluator(const XprType& xpr)
     : m_functor(xpr.functor()),
       m_lhsImpl(xpr.lhs()), 
@@ -617,6 +684,7 @@ public:
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_lhsImpl.nonZerosEstimate();
   }
@@ -635,6 +703,7 @@ protected:
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 Derived& SparseMatrixBase<Derived>::operator+=(const EigenBase<OtherDerived> &other)
 {
   call_assignment(derived(), other.derived(), internal::add_assign_op<Scalar,typename OtherDerived::Scalar>());
@@ -643,6 +712,7 @@ Derived& SparseMatrixBase<Derived>::operator+=(const EigenBase<OtherDerived> &ot
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 Derived& SparseMatrixBase<Derived>::operator-=(const EigenBase<OtherDerived> &other)
 {
   call_assignment(derived(), other.derived(), internal::assign_op<Scalar,typename OtherDerived::Scalar>());
@@ -651,6 +721,7 @@ Derived& SparseMatrixBase<Derived>::operator-=(const EigenBase<OtherDerived> &ot
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE Derived &
 SparseMatrixBase<Derived>::operator-=(const SparseMatrixBase<OtherDerived> &other)
 {
@@ -659,6 +730,7 @@ SparseMatrixBase<Derived>::operator-=(const SparseMatrixBase<OtherDerived> &othe
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE Derived &
 SparseMatrixBase<Derived>::operator+=(const SparseMatrixBase<OtherDerived>& other)
 {
@@ -667,6 +739,7 @@ SparseMatrixBase<Derived>::operator+=(const SparseMatrixBase<OtherDerived>& othe
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 Derived& SparseMatrixBase<Derived>::operator+=(const DiagonalBase<OtherDerived>& other)
 {
   call_assignment_no_alias(derived(), other.derived(), internal::add_assign_op<Scalar,typename OtherDerived::Scalar>());
@@ -675,6 +748,7 @@ Derived& SparseMatrixBase<Derived>::operator+=(const DiagonalBase<OtherDerived>&
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 Derived& SparseMatrixBase<Derived>::operator-=(const DiagonalBase<OtherDerived>& other)
 {
   call_assignment_no_alias(derived(), other.derived(), internal::sub_assign_op<Scalar,typename OtherDerived::Scalar>());
@@ -683,6 +757,7 @@ Derived& SparseMatrixBase<Derived>::operator-=(const DiagonalBase<OtherDerived>&
     
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE const typename SparseMatrixBase<Derived>::template CwiseProductDenseReturnType<OtherDerived>::Type
 SparseMatrixBase<Derived>::cwiseProduct(const MatrixBase<OtherDerived> &other) const
 {
@@ -690,6 +765,7 @@ SparseMatrixBase<Derived>::cwiseProduct(const MatrixBase<OtherDerived> &other) c
 }
 
 template<typename DenseDerived, typename SparseDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE const CwiseBinaryOp<internal::scalar_sum_op<typename DenseDerived::Scalar,typename SparseDerived::Scalar>, const DenseDerived, const SparseDerived>
 operator+(const MatrixBase<DenseDerived> &a, const SparseMatrixBase<SparseDerived> &b)
 {
@@ -697,6 +773,7 @@ operator+(const MatrixBase<DenseDerived> &a, const SparseMatrixBase<SparseDerive
 }
 
 template<typename SparseDerived, typename DenseDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE const CwiseBinaryOp<internal::scalar_sum_op<typename SparseDerived::Scalar,typename DenseDerived::Scalar>, const SparseDerived, const DenseDerived>
 operator+(const SparseMatrixBase<SparseDerived> &a, const MatrixBase<DenseDerived> &b)
 {
@@ -704,6 +781,7 @@ operator+(const SparseMatrixBase<SparseDerived> &a, const MatrixBase<DenseDerive
 }
 
 template<typename DenseDerived, typename SparseDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE const CwiseBinaryOp<internal::scalar_difference_op<typename DenseDerived::Scalar,typename SparseDerived::Scalar>, const DenseDerived, const SparseDerived>
 operator-(const MatrixBase<DenseDerived> &a, const SparseMatrixBase<SparseDerived> &b)
 {
@@ -711,6 +789,7 @@ operator-(const MatrixBase<DenseDerived> &a, const SparseMatrixBase<SparseDerive
 }
 
 template<typename SparseDerived, typename DenseDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE const CwiseBinaryOp<internal::scalar_difference_op<typename SparseDerived::Scalar,typename DenseDerived::Scalar>, const SparseDerived, const DenseDerived>
 operator-(const SparseMatrixBase<SparseDerived> &a, const MatrixBase<DenseDerived> &b)
 {

--- a/Eigen/src/SparseCore/SparseCwiseUnaryOp.h
+++ b/Eigen/src/SparseCore/SparseCwiseUnaryOp.h
@@ -27,13 +27,15 @@ struct unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>
       CoeffReadCost = evaluator<ArgType>::CoeffReadCost + functor_traits<UnaryOp>::Cost,
       Flags = XprType::Flags
     };
-    
+
+    EIGEN_DEVICE_FUNC
     explicit unary_evaluator(const XprType& op) : m_functor(op.functor()), m_argImpl(op.nestedExpression())
     {
       EIGEN_INTERNAL_CHECK_COST_VALUE(functor_traits<UnaryOp>::Cost);
       EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
     }
     
+    EIGEN_DEVICE_FUNC
     inline Index nonZerosEstimate() const {
       return m_argImpl.nonZerosEstimate();
     }
@@ -54,13 +56,16 @@ class unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>::InnerIterat
     typedef typename unary_evaluator<CwiseUnaryOp<UnaryOp,ArgType>, IteratorBased>::EvalIterator Base;
   public:
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& unaryOp, Index outer)
       : Base(unaryOp.m_argImpl,outer), m_functor(unaryOp.m_functor)
     {}
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     { Base::operator++(); return *this; }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const { return m_functor(Base::value()); }
 
   protected:
@@ -82,7 +87,8 @@ struct unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>
       CoeffReadCost = evaluator<ArgType>::CoeffReadCost + functor_traits<ViewOp>::Cost,
       Flags = XprType::Flags
     };
-    
+
+    EIGEN_DEVICE_FUNC
     explicit unary_evaluator(const XprType& op) : m_functor(op.functor()), m_argImpl(op.nestedExpression())
     {
       EIGEN_INTERNAL_CHECK_COST_VALUE(functor_traits<ViewOp>::Cost);
@@ -105,14 +111,18 @@ class unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>::InnerItera
     typedef typename unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>::EvalIterator Base;
   public:
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& unaryOp, Index outer)
       : Base(unaryOp.m_argImpl,outer), m_functor(unaryOp.m_functor)
     {}
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE InnerIterator& operator++()
     { Base::operator++(); return *this; }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar value() const { return m_functor(Base::value()); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar& valueRef() { return m_functor(Base::valueRef()); }
 
   protected:
@@ -122,6 +132,7 @@ class unary_evaluator<CwiseUnaryView<ViewOp,ArgType>, IteratorBased>::InnerItera
 } // end namespace internal
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE Derived&
 SparseMatrixBase<Derived>::operator*=(const Scalar& other)
 {
@@ -134,6 +145,7 @@ SparseMatrixBase<Derived>::operator*=(const Scalar& other)
 }
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 EIGEN_STRONG_INLINE Derived&
 SparseMatrixBase<Derived>::operator/=(const Scalar& other)
 {

--- a/Eigen/src/SparseCore/SparseDot.h
+++ b/Eigen/src/SparseCore/SparseDot.h
@@ -15,6 +15,7 @@ namespace Eigen {
 template<typename Derived>
 template<typename OtherDerived>
 typename internal::traits<Derived>::Scalar
+EIGEN_DEVICE_FUNC
 SparseMatrixBase<Derived>::dot(const MatrixBase<OtherDerived>& other) const
 {
   EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived)
@@ -39,6 +40,7 @@ SparseMatrixBase<Derived>::dot(const MatrixBase<OtherDerived>& other) const
 
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 typename internal::traits<Derived>::Scalar
 SparseMatrixBase<Derived>::dot(const SparseMatrixBase<OtherDerived>& other) const
 {
@@ -73,6 +75,7 @@ SparseMatrixBase<Derived>::dot(const SparseMatrixBase<OtherDerived>& other) cons
 }
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 inline typename NumTraits<typename internal::traits<Derived>::Scalar>::Real
 SparseMatrixBase<Derived>::squaredNorm() const
 {
@@ -80,6 +83,7 @@ SparseMatrixBase<Derived>::squaredNorm() const
 }
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 inline typename NumTraits<typename internal::traits<Derived>::Scalar>::Real
 SparseMatrixBase<Derived>::norm() const
 {
@@ -88,6 +92,7 @@ SparseMatrixBase<Derived>::norm() const
 }
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 inline typename NumTraits<typename internal::traits<Derived>::Scalar>::Real
 SparseMatrixBase<Derived>::blueNorm() const
 {

--- a/Eigen/src/SparseCore/SparseFuzzy.h
+++ b/Eigen/src/SparseCore/SparseFuzzy.h
@@ -14,6 +14,7 @@ namespace Eigen {
   
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 bool SparseMatrixBase<Derived>::isApprox(const SparseMatrixBase<OtherDerived>& other, const RealScalar &prec) const
 {
   const typename internal::nested_eval<Derived,2,PlainObject>::type actualA(derived());

--- a/Eigen/src/SparseCore/SparseMatrix.h
+++ b/Eigen/src/SparseCore/SparseMatrix.h
@@ -135,58 +135,73 @@ class SparseMatrix
   public:
     
     /** \returns the number of rows of the matrix */
+    EIGEN_DEVICE_FUNC
     inline Index rows() const { return IsRowMajor ? m_outerSize : m_innerSize; }
     /** \returns the number of columns of the matrix */
+    EIGEN_DEVICE_FUNC
     inline Index cols() const { return IsRowMajor ? m_innerSize : m_outerSize; }
 
     /** \returns the number of rows (resp. columns) of the matrix if the storage order column major (resp. row major) */
+    EIGEN_DEVICE_FUNC
     inline Index innerSize() const { return m_innerSize; }
     /** \returns the number of columns (resp. rows) of the matrix if the storage order column major (resp. row major) */
+    EIGEN_DEVICE_FUNC
     inline Index outerSize() const { return m_outerSize; }
     
     /** \returns a const pointer to the array of values.
       * This function is aimed at interoperability with other libraries.
       * \sa innerIndexPtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline const Scalar* valuePtr() const { return m_data.valuePtr(); }
     /** \returns a non-const pointer to the array of values.
       * This function is aimed at interoperability with other libraries.
       * \sa innerIndexPtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline Scalar* valuePtr() { return m_data.valuePtr(); }
 
     /** \returns a const pointer to the array of inner indices.
       * This function is aimed at interoperability with other libraries.
       * \sa valuePtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerIndexPtr() const { return m_data.indexPtr(); }
     /** \returns a non-const pointer to the array of inner indices.
       * This function is aimed at interoperability with other libraries.
       * \sa valuePtr(), outerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerIndexPtr() { return m_data.indexPtr(); }
 
     /** \returns a const pointer to the array of the starting positions of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \sa valuePtr(), innerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* outerIndexPtr() const { return m_outerIndex; }
     /** \returns a non-const pointer to the array of the starting positions of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \sa valuePtr(), innerIndexPtr() */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* outerIndexPtr() { return m_outerIndex; }
 
     /** \returns a const pointer to the array of the number of non zeros of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \warning it returns the null pointer 0 in compressed mode */
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerNonZeroPtr() const { return m_innerNonZeros; }
     /** \returns a non-const pointer to the array of the number of non zeros of the inner vectors.
       * This function is aimed at interoperability with other libraries.
       * \warning it returns the null pointer 0 in compressed mode */
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerNonZeroPtr() { return m_innerNonZeros; }
 
     /** \internal */
+    EIGEN_DEVICE_FUNC
     inline Storage& data() { return m_data; }
     /** \internal */
+    EIGEN_DEVICE_FUNC
     inline const Storage& data() const { return m_data; }
 
     /** \returns the value of the matrix at position \a i, \a j
       * This function returns Scalar(0) if the element is an explicit \em zero */
+    EIGEN_DEVICE_FUNC
     inline Scalar coeff(Index row, Index col) const
     {
       eigen_assert(row>=0 && row<rows() && col>=0 && col<cols());
@@ -205,6 +220,7 @@ class SparseMatrix
       * This is a O(log(nnz_j)) operation (binary search) plus the cost of insert(Index,Index)
       * function if the element does not already exist.
       */
+    EIGEN_DEVICE_FUNC
     inline Scalar& coeffRef(Index row, Index col)
     {
       eigen_assert(row>=0 && row<rows() && col>=0 && col<cols());
@@ -239,6 +255,7 @@ class SparseMatrix
       * if the elements of each inner vector are inserted in increasing inner index order, and in O(nnz_j) for a random insertion.
       *
       */
+    EIGEN_DEVICE_FUNC
     Scalar& insert(Index row, Index col);
 
   public:
@@ -250,6 +267,7 @@ class SparseMatrix
       * 
       * \sa resize(Index,Index), data()
       */
+    EIGEN_DEVICE_FUNC
     inline void setZero()
     {
       m_data.clear();
@@ -261,6 +279,7 @@ class SparseMatrix
     /** Preallocates \a reserveSize non zeros.
       *
       * Precondition: the matrix must be in compressed mode. */
+    EIGEN_DEVICE_FUNC
     inline void reserve(Index reserveSize)
     {
       eigen_assert(isCompressed() && "This function does not make sense in non compressed mode.");
@@ -281,9 +300,11 @@ class SparseMatrix
       * Typical choices include std::vector<int>, Eigen::VectorXi, Eigen::VectorXi::Constant, etc.
       */
     template<class SizesType>
+    EIGEN_DEVICE_FUNC
     inline void reserve(const SizesType& reserveSizes);
     #else
     template<class SizesType>
+    EIGEN_DEVICE_FUNC
     inline void reserve(const SizesType& reserveSizes, const typename SizesType::value_type& enableif =
     #if (!EIGEN_COMP_MSVC) || (EIGEN_COMP_MSVC>=1500) // MSVC 2005 fails to compile with this typename
         typename
@@ -296,6 +317,7 @@ class SparseMatrix
     #endif // EIGEN_PARSED_BY_DOXYGEN
   protected:
     template<class SizesType>
+    EIGEN_DEVICE_FUNC
     inline void reserveInnerVectors(const SizesType& reserveSizes)
     {
       if(isCompressed())
@@ -364,7 +386,7 @@ class SparseMatrix
           }
         }
         
-        std::swap(m_outerIndex, newOuterIndex);
+        numext::swap(m_outerIndex, newOuterIndex);
         std::free(newOuterIndex);
       }
       
@@ -383,6 +405,7 @@ class SparseMatrix
       * After an insertion session, you should call the finalize() function.
       *
       * \sa insert, insertBackByOuterInner, startVec */
+    EIGEN_DEVICE_FUNC
     inline Scalar& insertBack(Index row, Index col)
     {
       return insertBackByOuterInner(IsRowMajor?row:col, IsRowMajor?col:row);
@@ -390,6 +413,7 @@ class SparseMatrix
 
     /** \internal
       * \sa insertBack, startVec */
+    EIGEN_DEVICE_FUNC
     inline Scalar& insertBackByOuterInner(Index outer, Index inner)
     {
       eigen_assert(Index(m_outerIndex[outer+1]) == m_data.size() && "Invalid ordered insertion (invalid outer index)");
@@ -402,6 +426,7 @@ class SparseMatrix
 
     /** \internal
       * \warning use it only if you know what you are doing */
+    EIGEN_DEVICE_FUNC
     inline Scalar& insertBackByOuterInnerUnordered(Index outer, Index inner)
     {
       Index p = m_outerIndex[outer+1];
@@ -412,6 +437,7 @@ class SparseMatrix
 
     /** \internal
       * \sa insertBack, insertBackByOuterInner */
+    EIGEN_DEVICE_FUNC
     inline void startVec(Index outer)
     {
       eigen_assert(m_outerIndex[outer]==Index(m_data.size()) && "You must call startVec for each inner vector sequentially");
@@ -422,6 +448,7 @@ class SparseMatrix
     /** \internal
       * Must be called after inserting a set of non zero entries using the low level compressed API.
       */
+    EIGEN_DEVICE_FUNC
     inline void finalize()
     {
       if(isCompressed())
@@ -443,20 +470,25 @@ class SparseMatrix
     //---
 
     template<typename InputIterators>
+    EIGEN_DEVICE_FUNC
     void setFromTriplets(const InputIterators& begin, const InputIterators& end);
 
     template<typename InputIterators,typename DupFunctor>
+    EIGEN_DEVICE_FUNC
     void setFromTriplets(const InputIterators& begin, const InputIterators& end, DupFunctor dup_func);
 
+    EIGEN_DEVICE_FUNC
     void sumupDuplicates() { collapseDuplicates(internal::scalar_sum_op<Scalar,Scalar>()); }
 
     template<typename DupFunctor>
+    EIGEN_DEVICE_FUNC
     void collapseDuplicates(DupFunctor dup_func = DupFunctor());
 
     //---
     
     /** \internal
       * same as insert(Index,Index) except that the indices are given relative to the storage order */
+    EIGEN_DEVICE_FUNC
     Scalar& insertByOuterInner(Index j, Index i)
     {
       return insert(IsRowMajor ? j : i, IsRowMajor ? i : j);
@@ -464,6 +496,7 @@ class SparseMatrix
 
     /** Turns the matrix into the \em compressed format.
       */
+    EIGEN_DEVICE_FUNC
     void makeCompressed()
     {
       if(isCompressed())
@@ -495,6 +528,7 @@ class SparseMatrix
     }
 
     /** Turns the matrix into the uncompressed mode */
+    EIGEN_DEVICE_FUNC
     void uncompress()
     {
       if(m_innerNonZeros != 0)
@@ -507,6 +541,7 @@ class SparseMatrix
     }
 
     /** Suppresses all nonzeros which are \b much \b smaller \b than \a reference under the tolerance \a epsilon */
+    EIGEN_DEVICE_FUNC
     void prune(const Scalar& reference, const RealScalar& epsilon = NumTraits<RealScalar>::dummy_precision())
     {
       prune(default_prunning_func(reference,epsilon));
@@ -520,6 +555,7 @@ class SparseMatrix
       * \sa prune(Scalar,RealScalar)
       */
     template<typename KeepFunc>
+    EIGEN_DEVICE_FUNC
     void prune(const KeepFunc& keep = KeepFunc())
     {
       // TODO optimize the uncompressed mode to avoid moving and allocating the data twice
@@ -553,6 +589,7 @@ class SparseMatrix
       *
       * \sa reserve(), setZero(), makeCompressed()
       */
+    EIGEN_DEVICE_FUNC
     void conservativeResize(Index rows, Index cols) 
     {
       // No change
@@ -621,6 +658,7 @@ class SparseMatrix
       * 
       * \sa reserve(), setZero()
       */
+    EIGEN_DEVICE_FUNC
     void resize(Index rows, Index cols)
     {
       const Index outerSize = IsRowMajor ? rows : cols;
@@ -644,21 +682,25 @@ class SparseMatrix
 
     /** \internal
       * Resize the nonzero vector to \a size */
+    EIGEN_DEVICE_FUNC
     void resizeNonZeros(Index size)
     {
       m_data.resize(size);
     }
 
     /** \returns a const expression of the diagonal coefficients. */
+    EIGEN_DEVICE_FUNC
     const ConstDiagonalReturnType diagonal() const { return ConstDiagonalReturnType(*this); }
     
     /** \returns a read-write expression of the diagonal coefficients.
       * \warning If the diagonal entries are written, then all diagonal
       * entries \b must already exist, otherwise an assertion will be raised.
       */
+    EIGEN_DEVICE_FUNC
     DiagonalReturnType diagonal() { return DiagonalReturnType(*this); }
 
     /** Default constructor yielding an empty \c 0 \c x \c 0 matrix */
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix()
       : m_outerSize(-1), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -667,6 +709,7 @@ class SparseMatrix
     }
 
     /** Constructs a \a rows \c x \a cols empty matrix */
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix(Index rows, Index cols)
       : m_outerSize(0), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -676,6 +719,7 @@ class SparseMatrix
 
     /** Constructs a sparse matrix from the sparse expression \a other */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix(const SparseMatrixBase<OtherDerived>& other)
       : m_outerSize(0), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -696,6 +740,7 @@ class SparseMatrix
     
     /** Constructs a sparse matrix from the sparse selfadjoint view \a other */
     template<typename OtherDerived, unsigned int UpLo>
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix(const SparseSelfAdjointView<OtherDerived, UpLo>& other)
       : m_outerSize(0), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -704,6 +749,7 @@ class SparseMatrix
     }
 
     /** Copy constructor (it performs a deep copy) */
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix(const SparseMatrix& other)
       : Base(), m_outerSize(0), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -713,6 +759,7 @@ class SparseMatrix
 
     /** \brief Copy constructor with in-place evaluation */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     SparseMatrix(const ReturnByValue<OtherDerived>& other)
       : Base(), m_outerSize(0), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -723,6 +770,7 @@ class SparseMatrix
     
     /** \brief Copy constructor with in-place evaluation */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     explicit SparseMatrix(const DiagonalBase<OtherDerived>& other)
       : Base(), m_outerSize(0), m_innerSize(0), m_outerIndex(0), m_innerNonZeros(0)
     {
@@ -732,18 +780,20 @@ class SparseMatrix
 
     /** Swaps the content of two sparse matrices of the same type.
       * This is a fast operation that simply swaps the underlying pointers and parameters. */
+    EIGEN_DEVICE_FUNC
     inline void swap(SparseMatrix& other)
     {
       //EIGEN_DBG_SPARSE(std::cout << "SparseMatrix:: swap\n");
-      std::swap(m_outerIndex, other.m_outerIndex);
-      std::swap(m_innerSize, other.m_innerSize);
-      std::swap(m_outerSize, other.m_outerSize);
-      std::swap(m_innerNonZeros, other.m_innerNonZeros);
+      numext::swap(m_outerIndex, other.m_outerIndex);
+      numext::swap(m_innerSize, other.m_innerSize);
+      numext::swap(m_outerSize, other.m_outerSize);
+      numext::swap(m_innerNonZeros, other.m_innerNonZeros);
       m_data.swap(other.m_data);
     }
 
     /** Sets *this to the identity matrix.
       * This function also turns the matrix into compressed mode, and drop any reserved memory. */
+    EIGEN_DEVICE_FUNC
     inline void setIdentity()
     {
       eigen_assert(rows() == cols() && "ONLY FOR SQUARED MATRICES");
@@ -754,6 +804,7 @@ class SparseMatrix
       std::free(m_innerNonZeros);
       m_innerNonZeros = 0;
     }
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix& operator=(const SparseMatrix& other)
     {
       if (other.isRValue())
@@ -781,6 +832,7 @@ class SparseMatrix
 
 #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline SparseMatrix& operator=(const EigenBase<OtherDerived>& other)
     { return Base::operator=(other.derived()); }
 
@@ -789,6 +841,7 @@ class SparseMatrix
 #endif // EIGEN_PARSED_BY_DOXYGEN
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     EIGEN_DONT_INLINE SparseMatrix& operator=(const SparseMatrixBase<OtherDerived>& other);
 
     friend std::ostream & operator << (std::ostream & s, const SparseMatrix& m)
@@ -837,6 +890,7 @@ class SparseMatrix
     }
 
     /** Destructor */
+    EIGEN_DEVICE_FUNC
     inline ~SparseMatrix()
     {
       std::free(m_outerIndex);
@@ -844,6 +898,7 @@ class SparseMatrix
     }
 
     /** Overloaded for performance */
+    EIGEN_DEVICE_FUNC
     Scalar sum() const;
     
 #   ifdef EIGEN_SPARSEMATRIX_PLUGIN
@@ -853,6 +908,7 @@ class SparseMatrix
 protected:
 
     template<typename Other>
+    EIGEN_DEVICE_FUNC
     void initAssignment(const Other& other)
     {
       resize(other.rows(), other.cols());
@@ -865,7 +921,7 @@ protected:
 
     /** \internal
       * \sa insert(Index,Index) */
-    EIGEN_DONT_INLINE Scalar& insertCompressed(Index row, Index col);
+    EIGEN_DEVICE_FUNC EIGEN_DONT_INLINE Scalar& insertCompressed(Index row, Index col);
 
     /** \internal
       * A vector object that is equal to 0 everywhere but v at the position i */
@@ -875,20 +931,24 @@ protected:
         StorageIndex m_value;
       public:
         typedef StorageIndex value_type;
+        EIGEN_DEVICE_FUNC
         SingletonVector(Index i, Index v)
           : m_index(convert_index(i)), m_value(convert_index(v))
         {}
 
+        EIGEN_DEVICE_FUNC
         StorageIndex operator[](Index i) const { return i==m_index ? m_value : 0; }
     };
 
     /** \internal
       * \sa insert(Index,Index) */
+    EIGEN_DEVICE_FUNC
     EIGEN_DONT_INLINE Scalar& insertUncompressed(Index row, Index col);
 
 public:
     /** \internal
       * \sa insert(Index,Index) */
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar& insertBackUncompressed(Index row, Index col)
     {
       const Index outer = IsRowMajor ? row : col;
@@ -1010,6 +1070,7 @@ protected:
     }
 
 private:
+  EIGEN_DEVICE_FUNC
   static void check_template_parameters()
   {
     EIGEN_STATIC_ASSERT(NumTraits<StorageIndex>::IsSigned,THE_INDEX_TYPE_MUST_BE_A_SIGNED_TYPE);
@@ -1017,7 +1078,9 @@ private:
   }
 
   struct default_prunning_func {
+    EIGEN_DEVICE_FUNC
     default_prunning_func(const Scalar& ref, const RealScalar& eps) : reference(ref), epsilon(eps) {}
+    EIGEN_DEVICE_FUNC
     inline bool operator() (const Index&, const Index&, const Scalar& value) const
     {
       return !internal::isMuchSmallerThan(value, reference, epsilon);
@@ -1030,6 +1093,7 @@ private:
 namespace internal {
 
 template<typename InputIterator, typename SparseMatrixType, typename DupFunctor>
+EIGEN_DEVICE_FUNC
 void set_from_triplets(const InputIterator& begin, const InputIterator& end, SparseMatrixType& mat, DupFunctor dup_func)
 {
   enum { IsRowMajor = SparseMatrixType::IsRowMajor };
@@ -1103,6 +1167,7 @@ void set_from_triplets(const InputIterator& begin, const InputIterator& end, Spa
   */
 template<typename Scalar, int _Options, typename _StorageIndex>
 template<typename InputIterators>
+EIGEN_DEVICE_FUNC
 void SparseMatrix<Scalar,_Options,_StorageIndex>::setFromTriplets(const InputIterators& begin, const InputIterators& end)
 {
   internal::set_from_triplets<InputIterators, SparseMatrix<Scalar,_Options,_StorageIndex> >(begin, end, *this, internal::scalar_sum_op<Scalar,Scalar>());
@@ -1119,6 +1184,7 @@ void SparseMatrix<Scalar,_Options,_StorageIndex>::setFromTriplets(const InputIte
   */
 template<typename Scalar, int _Options, typename _StorageIndex>
 template<typename InputIterators,typename DupFunctor>
+EIGEN_DEVICE_FUNC
 void SparseMatrix<Scalar,_Options,_StorageIndex>::setFromTriplets(const InputIterators& begin, const InputIterators& end, DupFunctor dup_func)
 {
   internal::set_from_triplets<InputIterators, SparseMatrix<Scalar,_Options,_StorageIndex>, DupFunctor>(begin, end, *this, dup_func);
@@ -1127,6 +1193,7 @@ void SparseMatrix<Scalar,_Options,_StorageIndex>::setFromTriplets(const InputIte
 /** \internal */
 template<typename Scalar, int _Options, typename _StorageIndex>
 template<typename DupFunctor>
+EIGEN_DEVICE_FUNC
 void SparseMatrix<Scalar,_Options,_StorageIndex>::collapseDuplicates(DupFunctor dup_func)
 {
   eigen_assert(!isCompressed());
@@ -1167,6 +1234,7 @@ void SparseMatrix<Scalar,_Options,_StorageIndex>::collapseDuplicates(DupFunctor 
 
 template<typename Scalar, int _Options, typename _StorageIndex>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE SparseMatrix<Scalar,_Options,_StorageIndex>& SparseMatrix<Scalar,_Options,_StorageIndex>::operator=(const SparseMatrixBase<OtherDerived>& other)
 {
   EIGEN_STATIC_ASSERT((internal::is_same<Scalar, typename OtherDerived::Scalar>::value),
@@ -1239,6 +1307,7 @@ EIGEN_DONT_INLINE SparseMatrix<Scalar,_Options,_StorageIndex>& SparseMatrix<Scal
 }
 
 template<typename _Scalar, int _Options, typename _StorageIndex>
+EIGEN_DEVICE_FUNC
 typename SparseMatrix<_Scalar,_Options,_StorageIndex>::Scalar& SparseMatrix<_Scalar,_Options,_StorageIndex>::insert(Index row, Index col)
 {
   eigen_assert(row>=0 && row<rows() && col>=0 && col<cols());
@@ -1359,6 +1428,7 @@ typename SparseMatrix<_Scalar,_Options,_StorageIndex>::Scalar& SparseMatrix<_Sca
 }
     
 template<typename _Scalar, int _Options, typename _StorageIndex>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE typename SparseMatrix<_Scalar,_Options,_StorageIndex>::Scalar& SparseMatrix<_Scalar,_Options,_StorageIndex>::insertUncompressed(Index row, Index col)
 {
   eigen_assert(!isCompressed());
@@ -1391,6 +1461,7 @@ EIGEN_DONT_INLINE typename SparseMatrix<_Scalar,_Options,_StorageIndex>::Scalar&
 }
 
 template<typename _Scalar, int _Options, typename _StorageIndex>
+EIGEN_DEVICE_FUNC
 EIGEN_DONT_INLINE typename SparseMatrix<_Scalar,_Options,_StorageIndex>::Scalar& SparseMatrix<_Scalar,_Options,_StorageIndex>::insertCompressed(Index row, Index col)
 {
   eigen_assert(isCompressed());
@@ -1505,7 +1576,9 @@ struct evaluator<SparseMatrix<_Scalar,_Options,_StorageIndex> >
 {
   typedef evaluator<SparseCompressedBase<SparseMatrix<_Scalar,_Options,_StorageIndex> > > Base;
   typedef SparseMatrix<_Scalar,_Options,_StorageIndex> SparseMatrixType;
+  EIGEN_DEVICE_FUNC
   evaluator() : Base() {}
+  EIGEN_DEVICE_FUNC
   explicit evaluator(const SparseMatrixType &mat) : Base(mat) {}
 };
 

--- a/Eigen/src/SparseCore/SparseMatrixBase.h
+++ b/Eigen/src/SparseCore/SparseMatrixBase.h
@@ -52,6 +52,7 @@ template<typename Derived> class SparseMatrixBase
     typedef Matrix<Scalar,Dynamic,1> ScalarVector;
     
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator=(const EigenBase<OtherDerived> &other);
 
     enum {
@@ -140,8 +141,11 @@ template<typename Derived> class SparseMatrixBase
     typedef Matrix<Scalar,EIGEN_SIZE_MAX(RowsAtCompileTime,ColsAtCompileTime),
                           EIGEN_SIZE_MAX(RowsAtCompileTime,ColsAtCompileTime)> SquareMatrixType;
 
+    EIGEN_DEVICE_FUNC
     inline const Derived& derived() const { return *static_cast<const Derived*>(this); }
+    EIGEN_DEVICE_FUNC
     inline Derived& derived() { return *static_cast<Derived*>(this); }
+    EIGEN_DEVICE_FUNC
     inline Derived& const_cast_derived() const
     { return *static_cast<Derived*>(const_cast<SparseMatrixBase*>(this)); }
 
@@ -173,44 +177,57 @@ template<typename Derived> class SparseMatrixBase
 #undef EIGEN_DOC_BLOCK_ADDONS_INNER_PANEL_IF
 
     /** \returns the number of rows. \sa cols() */
-    inline Index rows() const { return derived().rows(); }
+    EIGEN_DEVICE_FUNC inline Index rows() const { return derived().rows(); }
     /** \returns the number of columns. \sa rows() */
+    EIGEN_DEVICE_FUNC
     inline Index cols() const { return derived().cols(); }
     /** \returns the number of coefficients, which is \a rows()*cols().
       * \sa rows(), cols(). */
+    EIGEN_DEVICE_FUNC
     inline Index size() const { return rows() * cols(); }
     /** \returns true if either the number of rows or the number of columns is equal to 1.
       * In other words, this function returns
       * \code rows()==1 || cols()==1 \endcode
       * \sa rows(), cols(), IsVectorAtCompileTime. */
+    EIGEN_DEVICE_FUNC
     inline bool isVector() const { return rows()==1 || cols()==1; }
     /** \returns the size of the storage major dimension,
       * i.e., the number of columns for a columns major matrix, and the number of rows otherwise */
+    EIGEN_DEVICE_FUNC
     Index outerSize() const { return (int(Flags)&RowMajorBit) ? this->rows() : this->cols(); }
     /** \returns the size of the inner dimension according to the storage order,
       * i.e., the number of rows for a columns major matrix, and the number of cols otherwise */
+    EIGEN_DEVICE_FUNC
     Index innerSize() const { return (int(Flags)&RowMajorBit) ? this->cols() : this->rows(); }
 
+    EIGEN_DEVICE_FUNC
     bool isRValue() const { return m_isRValue; }
+    EIGEN_DEVICE_FUNC
     Derived& markAsRValue() { m_isRValue = true; return derived(); }
 
+    EIGEN_DEVICE_FUNC
     SparseMatrixBase() : m_isRValue(false) { /* TODO check flags */ }
 
     
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator=(const ReturnByValue<OtherDerived>& other);
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline Derived& operator=(const SparseMatrixBase<OtherDerived>& other);
 
+    EIGEN_DEVICE_FUNC
     inline Derived& operator=(const Derived& other);
 
   protected:
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline Derived& assign(const OtherDerived& other);
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline void assignGeneric(const OtherDerived& other);
 
   public:
@@ -265,21 +282,29 @@ template<typename Derived> class SparseMatrixBase
     }
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator+=(const SparseMatrixBase<OtherDerived>& other);
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator-=(const SparseMatrixBase<OtherDerived>& other);
     
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator+=(const DiagonalBase<OtherDerived>& other);
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator-=(const DiagonalBase<OtherDerived>& other);
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator+=(const EigenBase<OtherDerived> &other);
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator-=(const EigenBase<OtherDerived> &other);
 
+    EIGEN_DEVICE_FUNC
     Derived& operator*=(const Scalar& other);
+    EIGEN_DEVICE_FUNC
     Derived& operator/=(const Scalar& other);
 
     template<typename OtherDerived> struct CwiseProductDenseReturnType {
@@ -293,78 +318,99 @@ template<typename Derived> class SparseMatrixBase
     };
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE const typename CwiseProductDenseReturnType<OtherDerived>::Type
     cwiseProduct(const MatrixBase<OtherDerived> &other) const;
 
     // sparse * diagonal
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     const Product<Derived,OtherDerived>
     operator*(const DiagonalBase<OtherDerived> &other) const
     { return Product<Derived,OtherDerived>(derived(), other.derived()); }
 
     // diagonal * sparse
     template<typename OtherDerived> friend
+    EIGEN_DEVICE_FUNC
     const Product<OtherDerived,Derived>
     operator*(const DiagonalBase<OtherDerived> &lhs, const SparseMatrixBase& rhs)
     { return Product<OtherDerived,Derived>(lhs.derived(), rhs.derived()); }
     
     // sparse * sparse
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     const Product<Derived,OtherDerived,AliasFreeProduct>
     operator*(const SparseMatrixBase<OtherDerived> &other) const;
     
     // sparse * dense
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     const Product<Derived,OtherDerived>
     operator*(const MatrixBase<OtherDerived> &other) const
     { return Product<Derived,OtherDerived>(derived(), other.derived()); }
     
     // dense * sparse
     template<typename OtherDerived> friend
+    EIGEN_DEVICE_FUNC
     const Product<OtherDerived,Derived>
     operator*(const MatrixBase<OtherDerived> &lhs, const SparseMatrixBase& rhs)
     { return Product<OtherDerived,Derived>(lhs.derived(), rhs.derived()); }
     
      /** \returns an expression of P H P^-1 where H is the matrix represented by \c *this */
+    EIGEN_DEVICE_FUNC
     SparseSymmetricPermutationProduct<Derived,Upper|Lower> twistedBy(const PermutationMatrix<Dynamic,Dynamic,StorageIndex>& perm) const
     {
       return SparseSymmetricPermutationProduct<Derived,Upper|Lower>(derived(), perm);
     }
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Derived& operator*=(const SparseMatrixBase<OtherDerived>& other);
 
     template<int Mode>
+    EIGEN_DEVICE_FUNC
     inline const TriangularView<const Derived, Mode> triangularView() const;
     
     template<unsigned int UpLo> struct SelfAdjointViewReturnType { typedef SparseSelfAdjointView<Derived, UpLo> Type; };
     template<unsigned int UpLo> struct ConstSelfAdjointViewReturnType { typedef const SparseSelfAdjointView<const Derived, UpLo> Type; };
 
-    template<unsigned int UpLo> inline 
+    template<unsigned int UpLo>
+    EIGEN_DEVICE_FUNC inline
     typename ConstSelfAdjointViewReturnType<UpLo>::Type selfadjointView() const;
-    template<unsigned int UpLo> inline
+    template<unsigned int UpLo>
+    EIGEN_DEVICE_FUNC inline
     typename SelfAdjointViewReturnType<UpLo>::Type selfadjointView();
 
-    template<typename OtherDerived> Scalar dot(const MatrixBase<OtherDerived>& other) const;
-    template<typename OtherDerived> Scalar dot(const SparseMatrixBase<OtherDerived>& other) const;
-    RealScalar squaredNorm() const;
-    RealScalar norm()  const;
-    RealScalar blueNorm() const;
+    template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
+    Scalar dot(const MatrixBase<OtherDerived>& other) const;
+    template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
+    Scalar dot(const SparseMatrixBase<OtherDerived>& other) const;
+    EIGEN_DEVICE_FUNC RealScalar squaredNorm() const;
+    EIGEN_DEVICE_FUNC RealScalar norm()  const;
+    EIGEN_DEVICE_FUNC RealScalar blueNorm() const;
 
+    EIGEN_DEVICE_FUNC
     TransposeReturnType transpose() { return TransposeReturnType(derived()); }
+    EIGEN_DEVICE_FUNC
     const ConstTransposeReturnType transpose() const { return ConstTransposeReturnType(derived()); }
+    EIGEN_DEVICE_FUNC
     const AdjointReturnType adjoint() const { return AdjointReturnType(transpose()); }
 
+    EIGEN_DEVICE_FUNC
     DenseMatrixType toDense() const
     {
       return DenseMatrixType(derived());
     }
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     bool isApprox(const SparseMatrixBase<OtherDerived>& other,
                   const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const;
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     bool isApprox(const MatrixBase<OtherDerived>& other,
                   const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const
     { return toDense().isApprox(other,prec); }
@@ -374,11 +420,14 @@ template<typename Derived> class SparseMatrixBase
       * Notice that in the case of a plain matrix or vector (not an expression) this function just returns
       * a const reference, in order to avoid a useless copy.
       */
+    EIGEN_DEVICE_FUNC
     inline const typename internal::eval<Derived>::type eval() const
     { return typename internal::eval<Derived>::type(derived()); }
 
+    EIGEN_DEVICE_FUNC
     Scalar sum() const;
     
+    EIGEN_DEVICE_FUNC
     inline const SparseView<Derived>
     pruned(const Scalar& reference = Scalar(0), const RealScalar& epsilon = NumTraits<Scalar>::dummy_precision()) const;
 
@@ -386,11 +435,14 @@ template<typename Derived> class SparseMatrixBase
 
     bool m_isRValue;
 
+    EIGEN_DEVICE_FUNC
     static inline StorageIndex convert_index(const Index idx) {
       return internal::convert_index<StorageIndex>(idx);
     }
   private:
-    template<typename Dest> void evalTo(Dest &) const;
+    template<typename Dest>
+    EIGEN_DEVICE_FUNC
+    void evalTo(Dest &) const;
 };
 
 } // end namespace Eigen

--- a/Eigen/src/SparseCore/SparsePermutation.h
+++ b/Eigen/src/SparseCore/SparsePermutation.h
@@ -35,6 +35,7 @@ struct permutation_matrix_product<ExpressionType, Side, Transposed, SparseShape>
         SparseMatrix<Scalar,int(SrcStorageOrder)==RowMajor?ColMajor:RowMajor,StorageIndex> >::type ReturnType;
 
     template<typename Dest,typename PermutationType>
+    EIGEN_DEVICE_FUNC
     static inline void run(Dest& dst, const PermutationType& perm, const ExpressionType& xpr)
     {
       MatrixType mat(xpr);
@@ -104,6 +105,7 @@ struct product_evaluator<Product<Lhs, Rhs, AliasFreeProduct>, ProductTag, Permut
     Flags = Base::Flags | EvalBeforeNestingBit
   };
 
+  EIGEN_DEVICE_FUNC
   explicit product_evaluator(const XprType& xpr)
     : m_result(xpr.rows(), xpr.cols())
   {
@@ -127,6 +129,7 @@ struct product_evaluator<Product<Lhs, Rhs, AliasFreeProduct>, ProductTag, Sparse
     Flags = Base::Flags | EvalBeforeNestingBit
   };
 
+  EIGEN_DEVICE_FUNC
   explicit product_evaluator(const XprType& xpr)
     : m_result(xpr.rows(), xpr.cols())
   {
@@ -143,6 +146,7 @@ protected:
 /** \returns the matrix with the permutation applied to the columns
   */
 template<typename SparseDerived, typename PermDerived>
+EIGEN_DEVICE_FUNC
 inline const Product<SparseDerived, PermDerived, AliasFreeProduct>
 operator*(const SparseMatrixBase<SparseDerived>& matrix, const PermutationBase<PermDerived>& perm)
 { return Product<SparseDerived, PermDerived, AliasFreeProduct>(matrix.derived(), perm.derived()); }
@@ -150,6 +154,7 @@ operator*(const SparseMatrixBase<SparseDerived>& matrix, const PermutationBase<P
 /** \returns the matrix with the permutation applied to the rows
   */
 template<typename SparseDerived, typename PermDerived>
+EIGEN_DEVICE_FUNC
 inline const Product<PermDerived, SparseDerived, AliasFreeProduct>
 operator*( const PermutationBase<PermDerived>& perm, const SparseMatrixBase<SparseDerived>& matrix)
 { return  Product<PermDerived, SparseDerived, AliasFreeProduct>(perm.derived(), matrix.derived()); }
@@ -158,6 +163,7 @@ operator*( const PermutationBase<PermDerived>& perm, const SparseMatrixBase<Spar
 /** \returns the matrix with the inverse permutation applied to the columns.
   */
 template<typename SparseDerived, typename PermutationType>
+EIGEN_DEVICE_FUNC
 inline const Product<SparseDerived, Inverse<PermutationType>, AliasFreeProduct>
 operator*(const SparseMatrixBase<SparseDerived>& matrix, const InverseImpl<PermutationType, PermutationStorage>& tperm)
 {
@@ -167,6 +173,7 @@ operator*(const SparseMatrixBase<SparseDerived>& matrix, const InverseImpl<Permu
 /** \returns the matrix with the inverse permutation applied to the rows.
   */
 template<typename SparseDerived, typename PermutationType>
+EIGEN_DEVICE_FUNC
 inline const Product<Inverse<PermutationType>, SparseDerived, AliasFreeProduct>
 operator*(const InverseImpl<PermutationType,PermutationStorage>& tperm, const SparseMatrixBase<SparseDerived>& matrix)
 {

--- a/Eigen/src/SparseCore/SparseProduct.h
+++ b/Eigen/src/SparseCore/SparseProduct.h
@@ -25,6 +25,7 @@ namespace Eigen {
   * */
 template<typename Derived>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 inline const Product<Derived,OtherDerived,AliasFreeProduct>
 SparseMatrixBase<Derived>::operator*(const SparseMatrixBase<OtherDerived> &other) const
 {
@@ -38,6 +39,7 @@ template<typename Lhs, typename Rhs, int ProductType>
 struct generic_product_impl<Lhs, Rhs, SparseShape, SparseShape, ProductType>
 {
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void evalTo(Dest& dst, const Lhs& lhs, const Rhs& rhs)
   {
     evalTo(dst, lhs, rhs, typename evaluator_traits<Dest>::Shape());
@@ -45,6 +47,7 @@ struct generic_product_impl<Lhs, Rhs, SparseShape, SparseShape, ProductType>
 
   // dense += sparse * sparse
   template<typename Dest,typename ActualLhs>
+  EIGEN_DEVICE_FUNC
   static void addTo(Dest& dst, const ActualLhs& lhs, const Rhs& rhs, typename enable_if<is_same<typename evaluator_traits<Dest>::Shape,DenseShape>::value,int*>::type* = 0)
   {
     typedef typename nested_eval<ActualLhs,Dynamic>::type LhsNested;
@@ -57,6 +60,7 @@ struct generic_product_impl<Lhs, Rhs, SparseShape, SparseShape, ProductType>
 
   // dense -= sparse * sparse
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void subTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, typename enable_if<is_same<typename evaluator_traits<Dest>::Shape,DenseShape>::value,int*>::type* = 0)
   {
     addTo(dst, -lhs, rhs);
@@ -66,6 +70,7 @@ protected:
 
   // sparse = sparse * sparse
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void evalTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, SparseShape)
   {
     typedef typename nested_eval<Lhs,Dynamic>::type LhsNested;
@@ -78,6 +83,7 @@ protected:
 
   // dense = sparse * sparse
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void evalTo(Dest& dst, const Lhs& lhs, const Rhs& rhs, DenseShape)
   {
     dst.setZero();
@@ -102,6 +108,7 @@ template< typename DstXprType, typename Lhs, typename Rhs>
 struct Assignment<DstXprType, Product<Lhs,Rhs,AliasFreeProduct>, internal::assign_op<typename DstXprType::Scalar,typename Product<Lhs,Rhs,AliasFreeProduct>::Scalar>, Sparse2Dense>
 {
   typedef Product<Lhs,Rhs,AliasFreeProduct> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &)
   {
     Index dstRows = src.rows();
@@ -118,6 +125,7 @@ template< typename DstXprType, typename Lhs, typename Rhs>
 struct Assignment<DstXprType, Product<Lhs,Rhs,AliasFreeProduct>, internal::add_assign_op<typename DstXprType::Scalar,typename Product<Lhs,Rhs,AliasFreeProduct>::Scalar>, Sparse2Dense>
 {
   typedef Product<Lhs,Rhs,AliasFreeProduct> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::add_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &)
   {
     generic_product_impl<Lhs, Rhs>::addTo(dst,src.lhs(),src.rhs());
@@ -129,6 +137,7 @@ template< typename DstXprType, typename Lhs, typename Rhs>
 struct Assignment<DstXprType, Product<Lhs,Rhs,AliasFreeProduct>, internal::sub_assign_op<typename DstXprType::Scalar,typename Product<Lhs,Rhs,AliasFreeProduct>::Scalar>, Sparse2Dense>
 {
   typedef Product<Lhs,Rhs,AliasFreeProduct> SrcXprType;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::sub_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> &)
   {
     generic_product_impl<Lhs, Rhs>::subTo(dst,src.lhs(),src.rhs());
@@ -143,6 +152,7 @@ struct unary_evaluator<SparseView<Product<Lhs, Rhs, Options> >, IteratorBased>
   typedef typename XprType::PlainObject PlainObject;
   typedef evaluator<PlainObject> Base;
 
+  EIGEN_DEVICE_FUNC
   explicit unary_evaluator(const XprType& xpr)
     : m_result(xpr.rows(), xpr.cols())
   {

--- a/Eigen/src/SparseCore/SparseRedux.h
+++ b/Eigen/src/SparseCore/SparseRedux.h
@@ -13,6 +13,7 @@
 namespace Eigen { 
 
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 typename internal::traits<Derived>::Scalar
 SparseMatrixBase<Derived>::sum() const
 {
@@ -26,6 +27,7 @@ SparseMatrixBase<Derived>::sum() const
 }
 
 template<typename _Scalar, int _Options, typename _Index>
+EIGEN_DEVICE_FUNC
 typename internal::traits<SparseMatrix<_Scalar,_Options,_Index> >::Scalar
 SparseMatrix<_Scalar,_Options,_Index>::sum() const
 {
@@ -37,6 +39,7 @@ SparseMatrix<_Scalar,_Options,_Index>::sum() const
 }
 
 template<typename _Scalar, int _Options, typename _Index>
+EIGEN_DEVICE_FUNC
 typename internal::traits<SparseVector<_Scalar,_Options, _Index> >::Scalar
 SparseVector<_Scalar,_Options,_Index>::sum() const
 {

--- a/Eigen/src/SparseCore/SparseSelfAdjointView.h
+++ b/Eigen/src/SparseCore/SparseSelfAdjointView.h
@@ -33,9 +33,11 @@ struct traits<SparseSelfAdjointView<MatrixType,Mode> > : traits<MatrixType> {
 };
 
 template<int SrcMode,int DstMode,typename MatrixType,int DestOrder>
+EIGEN_DEVICE_FUNC
 void permute_symm_to_symm(const MatrixType& mat, SparseMatrix<typename MatrixType::Scalar,DestOrder,typename MatrixType::StorageIndex>& _dest, const typename MatrixType::StorageIndex* perm = 0);
 
 template<int Mode,typename MatrixType,int DestOrder>
+EIGEN_DEVICE_FUNC
 void permute_symm_to_fullsymm(const MatrixType& mat, SparseMatrix<typename MatrixType::Scalar,DestOrder,typename MatrixType::StorageIndex>& _dest, const typename MatrixType::StorageIndex* perm = 0);
 
 }
@@ -59,16 +61,21 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
     typedef typename internal::ref_selector<MatrixType>::non_const_type MatrixTypeNested;
     typedef typename internal::remove_all<MatrixTypeNested>::type _MatrixTypeNested;
     
+    EIGEN_DEVICE_FUNC
     explicit inline SparseSelfAdjointView(MatrixType& matrix) : m_matrix(matrix)
     {
       eigen_assert(rows()==cols() && "SelfAdjointView is only for squared matrices");
     }
 
+    EIGEN_DEVICE_FUNC
     inline Index rows() const { return m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
     inline Index cols() const { return m_matrix.cols(); }
 
     /** \internal \returns a reference to the nested matrix */
+    EIGEN_DEVICE_FUNC
     const _MatrixTypeNested& matrix() const { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     typename internal::remove_reference<MatrixTypeNested>::type& matrix() { return m_matrix; }
 
     /** \returns an expression of the matrix product between a sparse self-adjoint matrix \c *this and a sparse matrix \a rhs.
@@ -77,6 +84,7 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
       * Indeed, the SparseSelfadjointView operand is first copied into a temporary SparseMatrix before computing the product.
       */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Product<SparseSelfAdjointView, OtherDerived>
     operator*(const SparseMatrixBase<OtherDerived>& rhs) const
     {
@@ -89,6 +97,7 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
       * Indeed, the SparseSelfadjointView operand is first copied into a temporary SparseMatrix before computing the product.
       */
     template<typename OtherDerived> friend
+    EIGEN_DEVICE_FUNC
     Product<OtherDerived, SparseSelfAdjointView>
     operator*(const SparseMatrixBase<OtherDerived>& lhs, const SparseSelfAdjointView& rhs)
     {
@@ -97,6 +106,7 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
     
     /** Efficient sparse self-adjoint matrix times dense vector/matrix product */
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     Product<SparseSelfAdjointView,OtherDerived>
     operator*(const MatrixBase<OtherDerived>& rhs) const
     {
@@ -105,6 +115,7 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
 
     /** Efficient dense vector/matrix times sparse self-adjoint matrix product */
     template<typename OtherDerived> friend
+    EIGEN_DEVICE_FUNC
     Product<OtherDerived,SparseSelfAdjointView>
     operator*(const MatrixBase<OtherDerived>& lhs, const SparseSelfAdjointView& rhs)
     {
@@ -120,22 +131,26 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
       * call this function with u.adjoint().
       */
     template<typename DerivedU>
+    EIGEN_DEVICE_FUNC
     SparseSelfAdjointView& rankUpdate(const SparseMatrixBase<DerivedU>& u, const Scalar& alpha = Scalar(1));
     
     /** \returns an expression of P H P^-1 */
     // TODO implement twists in a more evaluator friendly fashion
+    EIGEN_DEVICE_FUNC
     SparseSymmetricPermutationProduct<_MatrixTypeNested,Mode> twistedBy(const PermutationMatrix<Dynamic,Dynamic,StorageIndex>& perm) const
     {
       return SparseSymmetricPermutationProduct<_MatrixTypeNested,Mode>(m_matrix, perm);
     }
 
     template<typename SrcMatrixType,int SrcMode>
+    EIGEN_DEVICE_FUNC
     SparseSelfAdjointView& operator=(const SparseSymmetricPermutationProduct<SrcMatrixType,SrcMode>& permutedMatrix)
     {
       internal::call_assignment_no_alias_no_transpose(*this, permutedMatrix);
       return *this;
     }
 
+    EIGEN_DEVICE_FUNC
     SparseSelfAdjointView& operator=(const SparseSelfAdjointView& src)
     {
       PermutationMatrix<Dynamic,Dynamic,StorageIndex> pnull;
@@ -143,12 +158,14 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
     }
 
     template<typename SrcMatrixType,unsigned int SrcMode>
+    EIGEN_DEVICE_FUNC
     SparseSelfAdjointView& operator=(const SparseSelfAdjointView<SrcMatrixType,SrcMode>& src)
     {
       PermutationMatrix<Dynamic,Dynamic,StorageIndex> pnull;
       return *this = src.twistedBy(pnull);
     }
     
+    EIGEN_DEVICE_FUNC
     void resize(Index rows, Index cols)
     {
       EIGEN_ONLY_USED_FOR_DEBUG(rows);
@@ -172,6 +189,7 @@ template<typename MatrixType, unsigned int _Mode> class SparseSelfAdjointView
 
 template<typename Derived>
 template<unsigned int UpLo>
+EIGEN_DEVICE_FUNC
 typename SparseMatrixBase<Derived>::template ConstSelfAdjointViewReturnType<UpLo>::Type SparseMatrixBase<Derived>::selfadjointView() const
 {
   return SparseSelfAdjointView<const Derived, UpLo>(derived());
@@ -179,6 +197,7 @@ typename SparseMatrixBase<Derived>::template ConstSelfAdjointViewReturnType<UpLo
 
 template<typename Derived>
 template<unsigned int UpLo>
+EIGEN_DEVICE_FUNC
 typename SparseMatrixBase<Derived>::template SelfAdjointViewReturnType<UpLo>::Type SparseMatrixBase<Derived>::selfadjointView()
 {
   return SparseSelfAdjointView<Derived, UpLo>(derived());
@@ -190,6 +209,7 @@ typename SparseMatrixBase<Derived>::template SelfAdjointViewReturnType<UpLo>::Ty
 
 template<typename MatrixType, unsigned int Mode>
 template<typename DerivedU>
+EIGEN_DEVICE_FUNC
 SparseSelfAdjointView<MatrixType,Mode>&
 SparseSelfAdjointView<MatrixType,Mode>::rankUpdate(const SparseMatrixBase<DerivedU>& u, const Scalar& alpha)
 {
@@ -226,6 +246,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, SparseSelfAdjoint2Sparse>
   typedef internal::assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar> AssignOpType;
 
   template<typename DestScalar,int StorageOrder>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrix<DestScalar,StorageOrder,StorageIndex> &dst, const SrcXprType &src, const AssignOpType&/*func*/)
   {
     internal::permute_symm_to_fullsymm<SrcXprType::Mode>(src.matrix(), dst);
@@ -233,6 +254,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, SparseSelfAdjoint2Sparse>
 
   // FIXME: the handling of += and -= in sparse matrices should be cleanup so that next two overloads could be reduced to:
   template<typename DestScalar,int StorageOrder,typename AssignFunc>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrix<DestScalar,StorageOrder,StorageIndex> &dst, const SrcXprType &src, const AssignFunc& func)
   {
     SparseMatrix<DestScalar,StorageOrder,StorageIndex> tmp(src.rows(),src.cols());
@@ -241,6 +263,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, SparseSelfAdjoint2Sparse>
   }
 
   template<typename DestScalar,int StorageOrder>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrix<DestScalar,StorageOrder,StorageIndex> &dst, const SrcXprType &src,
                   const internal::add_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar>& /* func */)
   {
@@ -250,6 +273,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, SparseSelfAdjoint2Sparse>
   }
 
   template<typename DestScalar,int StorageOrder>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrix<DestScalar,StorageOrder,StorageIndex> &dst, const SrcXprType &src,
                   const internal::sub_assign_op<typename DstXprType::Scalar,typename SrcXprType::Scalar>& /* func */)
   {
@@ -259,6 +283,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, SparseSelfAdjoint2Sparse>
   }
   
   template<typename DestScalar>
+  EIGEN_DEVICE_FUNC
   static void run(DynamicSparseMatrix<DestScalar,ColMajor,StorageIndex>& dst, const SrcXprType &src, const AssignOpType&/*func*/)
   {
     // TODO directly evaluate into dst;
@@ -277,6 +302,7 @@ struct Assignment<DstXprType, SrcXprType, Functor, SparseSelfAdjoint2Sparse>
 namespace internal {
 
 template<int Mode, typename SparseLhsType, typename DenseRhsType, typename DenseResType, typename AlphaType>
+EIGEN_DEVICE_FUNC
 inline void sparse_selfadjoint_time_dense_product(const SparseLhsType& lhs, const DenseRhsType& rhs, DenseResType& res, const AlphaType& alpha)
 {
   EIGEN_ONLY_USED_FOR_DEBUG(alpha);
@@ -342,6 +368,7 @@ struct generic_product_impl<LhsView, Rhs, SparseSelfAdjointShape, DenseShape, Pr
 : generic_product_impl_base<LhsView, Rhs, generic_product_impl<LhsView, Rhs, SparseSelfAdjointShape, DenseShape, ProductType> >
 {
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void scaleAndAddTo(Dest& dst, const LhsView& lhsView, const Rhs& rhs, const typename Dest::Scalar& alpha)
   {
     typedef typename LhsView::_MatrixTypeNested Lhs;
@@ -359,6 +386,7 @@ struct generic_product_impl<Lhs, RhsView, DenseShape, SparseSelfAdjointShape, Pr
 : generic_product_impl_base<Lhs, RhsView, generic_product_impl<Lhs, RhsView, DenseShape, SparseSelfAdjointShape, ProductType> >
 {
   template<typename Dest>
+  EIGEN_DEVICE_FUNC
   static void scaleAndAddTo(Dest& dst, const Lhs& lhs, const RhsView& rhsView, const typename Dest::Scalar& alpha)
   {
     typedef typename RhsView::_MatrixTypeNested Rhs;
@@ -384,6 +412,7 @@ struct product_evaluator<Product<LhsView, Rhs, DefaultProduct>, ProductTag, Spar
   typedef typename XprType::PlainObject PlainObject;
   typedef evaluator<PlainObject> Base;
 
+  EIGEN_DEVICE_FUNC
   product_evaluator(const XprType& xpr)
     : m_lhs(xpr.lhs()), m_result(xpr.rows(), xpr.cols())
   {
@@ -404,6 +433,7 @@ struct product_evaluator<Product<Lhs, RhsView, DefaultProduct>, ProductTag, Spar
   typedef typename XprType::PlainObject PlainObject;
   typedef evaluator<PlainObject> Base;
 
+  EIGEN_DEVICE_FUNC
   product_evaluator(const XprType& xpr)
     : m_rhs(xpr.rhs()), m_result(xpr.rows(), xpr.cols())
   {
@@ -424,6 +454,7 @@ protected:
 namespace internal {
 
 template<int Mode,typename MatrixType,int DestOrder>
+EIGEN_DEVICE_FUNC
 void permute_symm_to_fullsymm(const MatrixType& mat, SparseMatrix<typename MatrixType::Scalar,DestOrder,typename MatrixType::StorageIndex>& _dest, const typename MatrixType::StorageIndex* perm)
 {
   typedef typename MatrixType::StorageIndex StorageIndex;
@@ -501,7 +532,7 @@ void permute_symm_to_fullsymm(const MatrixType& mat, SparseMatrix<typename Matri
       else if(( (Mode&Lower)==Lower && r>c) || ( (Mode&Upper)==Upper && r<c))
       {
         if(!StorageOrderMatch)
-          std::swap(ip,jp);
+          numext::swap(ip,jp);
         Index k = count[jp]++;
         dest.innerIndexPtr()[k] = ip;
         dest.valuePtr()[k] = it.value();
@@ -514,6 +545,7 @@ void permute_symm_to_fullsymm(const MatrixType& mat, SparseMatrix<typename Matri
 }
 
 template<int _SrcMode,int _DstMode,typename MatrixType,int DstOrder>
+EIGEN_DEVICE_FUNC
 void permute_symm_to_symm(const MatrixType& mat, SparseMatrix<typename MatrixType::Scalar,DstOrder,typename MatrixType::StorageIndex>& _dest, const typename MatrixType::StorageIndex* perm)
 {
   typedef typename MatrixType::StorageIndex StorageIndex;
@@ -571,7 +603,7 @@ void permute_symm_to_symm(const MatrixType& mat, SparseMatrix<typename MatrixTyp
       Index k = count[int(DstMode)==int(Lower) ? (std::min)(ip,jp) : (std::max)(ip,jp)]++;
       dest.innerIndexPtr()[k] = int(DstMode)==int(Lower) ? (std::max)(ip,jp) : (std::min)(ip,jp);
       
-      if(!StorageOrderMatch) std::swap(ip,jp);
+      if(!StorageOrderMatch) numext::swap(ip,jp);
       if( ((int(DstMode)==int(Lower) && ip<jp) || (int(DstMode)==int(Upper) && ip>jp)))
         dest.valuePtr()[k] = numext::conj(it.value());
       else
@@ -610,14 +642,19 @@ class SparseSymmetricPermutationProduct
     typedef typename MatrixType::Nested MatrixTypeNested;
     typedef typename internal::remove_all<MatrixTypeNested>::type NestedExpression;
     
+    EIGEN_DEVICE_FUNC
     SparseSymmetricPermutationProduct(const MatrixType& mat, const Perm& perm)
       : m_matrix(mat), m_perm(perm)
     {}
     
+    EIGEN_DEVICE_FUNC
     inline Index rows() const { return m_matrix.rows(); }
+    EIGEN_DEVICE_FUNC
     inline Index cols() const { return m_matrix.cols(); }
         
+    EIGEN_DEVICE_FUNC
     const NestedExpression& matrix() const { return m_matrix; }
+    EIGEN_DEVICE_FUNC
     const Perm& perm() const { return m_perm; }
     
   protected:
@@ -634,6 +671,7 @@ struct Assignment<DstXprType, SparseSymmetricPermutationProduct<MatrixType,Mode>
   typedef SparseSymmetricPermutationProduct<MatrixType,Mode> SrcXprType;
   typedef typename DstXprType::StorageIndex DstIndex;
   template<int Options>
+  EIGEN_DEVICE_FUNC
   static void run(SparseMatrix<Scalar,Options,DstIndex> &dst, const SrcXprType &src, const internal::assign_op<Scalar,typename MatrixType::Scalar> &)
   {
     // internal::permute_symm_to_fullsymm<Mode>(m_matrix,_dest,m_perm.indices().data());
@@ -643,6 +681,7 @@ struct Assignment<DstXprType, SparseSymmetricPermutationProduct<MatrixType,Mode>
   }
   
   template<typename DestType,unsigned int DestMode>
+  EIGEN_DEVICE_FUNC
   static void run(SparseSelfAdjointView<DestType,DestMode>& dst, const SrcXprType &src, const internal::assign_op<Scalar,typename MatrixType::Scalar> &)
   {
     internal::permute_symm_to_symm<Mode,DestMode>(src.matrix(),dst.matrix(),src.perm().indices().data());

--- a/Eigen/src/SparseCore/SparseSolverBase.h
+++ b/Eigen/src/SparseCore/SparseSolverBase.h
@@ -19,6 +19,7 @@ namespace internal {
   * The rhs is decomposed into small vertical panels which are solved through dense temporaries.
   */
 template<typename Decomposition, typename Rhs, typename Dest>
+EIGEN_DEVICE_FUNC
 typename enable_if<Rhs::ColsAtCompileTime!=1 && Dest::ColsAtCompileTime!=1>::type
 solve_sparse_through_dense_panels(const Decomposition &dec, const Rhs& rhs, Dest &dest)
 {
@@ -43,6 +44,7 @@ solve_sparse_through_dense_panels(const Decomposition &dec, const Rhs& rhs, Dest
 
 // Overload for vector as rhs
 template<typename Decomposition, typename Rhs, typename Dest>
+EIGEN_DEVICE_FUNC
 typename enable_if<Rhs::ColsAtCompileTime==1 || Dest::ColsAtCompileTime==1>::type
 solve_sparse_through_dense_panels(const Decomposition &dec, const Rhs& rhs, Dest &dest)
 {
@@ -69,14 +71,18 @@ class SparseSolverBase : internal::noncopyable
   public:
 
     /** Default constructor */
+    EIGEN_DEVICE_FUNC
     SparseSolverBase()
       : m_isInitialized(false)
     {}
 
+    EIGEN_DEVICE_FUNC
     ~SparseSolverBase()
     {}
 
+    EIGEN_DEVICE_FUNC
     Derived& derived() { return *static_cast<Derived*>(this); }
+    EIGEN_DEVICE_FUNC
     const Derived& derived() const { return *static_cast<const Derived*>(this); }
     
     /** \returns an expression of the solution x of \f$ A x = b \f$ using the current decomposition of A.
@@ -84,6 +90,7 @@ class SparseSolverBase : internal::noncopyable
       * \sa compute()
       */
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<Derived, Rhs>
     solve(const MatrixBase<Rhs>& b) const
     {
@@ -97,6 +104,7 @@ class SparseSolverBase : internal::noncopyable
       * \sa compute()
       */
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<Derived, Rhs>
     solve(const SparseMatrixBase<Rhs>& b) const
     {
@@ -108,6 +116,7 @@ class SparseSolverBase : internal::noncopyable
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     /** \internal default implementation of solving with a sparse rhs */
     template<typename Rhs,typename Dest>
+    EIGEN_DEVICE_FUNC
     void _solve_impl(const SparseMatrixBase<Rhs> &b, SparseMatrixBase<Dest> &dest) const
     {
       internal::solve_sparse_through_dense_panels(derived(), b.derived(), dest.derived());

--- a/Eigen/src/SparseCore/SparseTriangularView.h
+++ b/Eigen/src/SparseCore/SparseTriangularView.h
@@ -36,6 +36,7 @@ template<typename MatrixType, unsigned int Mode> class TriangularViewImpl<Matrix
     
   protected:
     // dummy solve function to make TriangularView happy.
+    EIGEN_DEVICE_FUNC
     void solve() const;
 
     typedef SparseMatrixBase<TriangularViewType> Base;
@@ -56,10 +57,14 @@ template<typename MatrixType, unsigned int Mode> class TriangularViewImpl<Matrix
     }
 
     /** Applies the inverse of \c *this to the dense vector or matrix \a other, "in-place" */
-    template<typename OtherDerived> void solveInPlace(MatrixBase<OtherDerived>& other) const;
+    template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
+    void solveInPlace(MatrixBase<OtherDerived>& other) const;
 
     /** Applies the inverse of \c *this to the sparse vector or matrix \a other, "in-place" */
-    template<typename OtherDerived> void solveInPlace(SparseMatrixBase<OtherDerived>& other) const;
+    template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
+    void solveInPlace(SparseMatrixBase<OtherDerived>& other) const;
   
 };
 
@@ -91,8 +96,10 @@ public:
     Flags = XprType::Flags
   };
     
+  EIGEN_DEVICE_FUNC
   explicit unary_evaluator(const XprType &xpr) : m_argImpl(xpr.nestedExpression()), m_arg(xpr.nestedExpression()) {}
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_argImpl.nonZerosEstimate();
   }
@@ -102,6 +109,7 @@ public:
       typedef EvalIterator Base;
     public:
 
+      EIGEN_DEVICE_FUNC
       EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& xprEval, Index outer)
         : Base(xprEval.m_argImpl,outer), m_returnOne(false), m_containsDiag(Base::outer()<xprEval.m_arg.innerSize())
       {
@@ -120,6 +128,7 @@ public:
         }
       }
 
+      EIGEN_DEVICE_FUNC
       EIGEN_STRONG_INLINE InnerIterator& operator++()
       {
         if(HasUnitDiag && m_returnOne)
@@ -137,6 +146,7 @@ public:
         return *this;
       }
       
+      EIGEN_DEVICE_FUNC
       EIGEN_STRONG_INLINE operator bool() const
       {
         if(HasUnitDiag && m_returnOne)
@@ -151,11 +161,13 @@ public:
 
 //       inline Index row() const { return (ArgType::Flags&RowMajorBit ? Base::outer() : this->index()); }
 //       inline Index col() const { return (ArgType::Flags&RowMajorBit ? this->index() : Base::outer()); }
+      EIGEN_DEVICE_FUNC
       inline StorageIndex index() const
       {
         if(HasUnitDiag && m_returnOne)  return internal::convert_index<StorageIndex>(Base::outer());
         else                            return Base::index();
       }
+      EIGEN_DEVICE_FUNC
       inline Scalar value() const
       {
         if(HasUnitDiag && m_returnOne)  return Scalar(1);
@@ -166,6 +178,7 @@ public:
       bool m_returnOne;
       bool m_containsDiag;
     private:
+      EIGEN_DEVICE_FUNC
       Scalar& valueRef();
   };
   
@@ -178,6 +191,7 @@ protected:
 
 template<typename Derived>
 template<int Mode>
+EIGEN_DEVICE_FUNC
 inline const TriangularView<const Derived, Mode>
 SparseMatrixBase<Derived>::triangularView() const
 {

--- a/Eigen/src/SparseCore/SparseVector.h
+++ b/Eigen/src/SparseCore/SparseVector.h
@@ -77,39 +77,56 @@ class SparseVector
     enum {
       Options = _Options
     };
-    
+
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index rows() const { return IsColVector ? m_size : 1; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index cols() const { return IsColVector ? 1 : m_size; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index innerSize() const { return m_size; }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Index outerSize() const { return 1; }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE const Scalar* valuePtr() const { return m_data.valuePtr(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE Scalar* valuePtr() { return m_data.valuePtr(); }
 
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE const StorageIndex* innerIndexPtr() const { return m_data.indexPtr(); }
+    EIGEN_DEVICE_FUNC
     EIGEN_STRONG_INLINE StorageIndex* innerIndexPtr() { return m_data.indexPtr(); }
 
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* outerIndexPtr() const { return 0; }
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* outerIndexPtr() { return 0; }
+    EIGEN_DEVICE_FUNC
     inline const StorageIndex* innerNonZeroPtr() const { return 0; }
+    EIGEN_DEVICE_FUNC
     inline StorageIndex* innerNonZeroPtr() { return 0; }
     
     /** \internal */
+    EIGEN_DEVICE_FUNC
     inline Storage& data() { return m_data; }
     /** \internal */
+    EIGEN_DEVICE_FUNC
     inline const Storage& data() const { return m_data; }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar coeff(Index row, Index col) const
     {
       eigen_assert(IsColVector ? (col==0 && row>=0 && row<m_size) : (row==0 && col>=0 && col<m_size));
       return coeff(IsColVector ? row : col);
     }
+    EIGEN_DEVICE_FUNC
     inline Scalar coeff(Index i) const
     {
       eigen_assert(i>=0 && i<m_size);
       return m_data.at(StorageIndex(i));
     }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& coeffRef(Index row, Index col)
     {
       eigen_assert(IsColVector ? (col==0 && row>=0 && row<m_size) : (row==0 && col>=0 && col<m_size));
@@ -122,6 +139,7 @@ class SparseVector
       *
       * This insertion might be very costly if the number of nonzeros above \a i is large.
       */
+    EIGEN_DEVICE_FUNC
     inline Scalar& coeffRef(Index i)
     {
       eigen_assert(i>=0 && i<m_size);
@@ -134,41 +152,49 @@ class SparseVector
     typedef typename Base::InnerIterator InnerIterator;
     typedef typename Base::ReverseInnerIterator ReverseInnerIterator;
 
+    EIGEN_DEVICE_FUNC
     inline void setZero() { m_data.clear(); }
 
     /** \returns the number of non zero coefficients */
+    EIGEN_DEVICE_FUNC
     inline Index nonZeros() const  { return m_data.size(); }
 
+    EIGEN_DEVICE_FUNC
     inline void startVec(Index outer)
     {
       EIGEN_UNUSED_VARIABLE(outer);
       eigen_assert(outer==0);
     }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& insertBackByOuterInner(Index outer, Index inner)
     {
       EIGEN_UNUSED_VARIABLE(outer);
       eigen_assert(outer==0);
       return insertBack(inner);
     }
+    EIGEN_DEVICE_FUNC
     inline Scalar& insertBack(Index i)
     {
       m_data.append(0, i);
       return m_data.value(m_data.size()-1);
     }
     
+    EIGEN_DEVICE_FUNC
     Scalar& insertBackByOuterInnerUnordered(Index outer, Index inner)
     {
       EIGEN_UNUSED_VARIABLE(outer);
       eigen_assert(outer==0);
       return insertBackUnordered(inner);
     }
+    EIGEN_DEVICE_FUNC
     inline Scalar& insertBackUnordered(Index i)
     {
       m_data.append(0, i);
       return m_data.value(m_data.size()-1);
     }
 
+    EIGEN_DEVICE_FUNC
     inline Scalar& insert(Index row, Index col)
     {
       eigen_assert(IsColVector ? (col==0 && row>=0 && row<m_size) : (row==0 && col>=0 && col<m_size));
@@ -179,6 +205,7 @@ class SparseVector
       eigen_assert(outer==0);
       return insert(inner);
     }
+    EIGEN_DEVICE_FUNC
     Scalar& insert(Index i)
     {
       eigen_assert(i>=0 && i<m_size);
@@ -201,12 +228,14 @@ class SparseVector
 
     /**
       */
+    EIGEN_DEVICE_FUNC
     inline void reserve(Index reserveSize) { m_data.reserve(reserveSize); }
 
-
+    EIGEN_DEVICE_FUNC
     inline void finalize() {}
 
     /** \copydoc SparseMatrix::prune(const Scalar&,const RealScalar&) */
+    EIGEN_DEVICE_FUNC
     void prune(const Scalar& reference, const RealScalar& epsilon = NumTraits<RealScalar>::dummy_precision())
     {
       m_data.prune(reference,epsilon);
@@ -220,6 +249,7 @@ class SparseVector
       *
       * \sa resize(Index)
       */
+    EIGEN_DEVICE_FUNC
     void resize(Index rows, Index cols)
     {
       eigen_assert((IsColVector ? cols : rows)==1 && "Outer dimension must equal 1");
@@ -230,6 +260,7 @@ class SparseVector
       * This method deletes all entries, thus leaving an empty sparse vector
       *
       * \sa  conservativeResize(), setZero() */
+    EIGEN_DEVICE_FUNC
     void resize(Index newSize)
     {
       m_size = newSize;
@@ -243,6 +274,7 @@ class SparseVector
       *
       * \sa reserve(), setZero()
       */
+    EIGEN_DEVICE_FUNC
     void conservativeResize(Index newSize)
     {
       if (newSize < m_size)
@@ -254,15 +286,20 @@ class SparseVector
       m_size = newSize;
     }
 
+    EIGEN_DEVICE_FUNC
     void resizeNonZeros(Index size) { m_data.resize(size); }
 
+    EIGEN_DEVICE_FUNC
     inline SparseVector() : m_size(0) { check_template_parameters(); resize(0); }
 
+    EIGEN_DEVICE_FUNC
     explicit inline SparseVector(Index size) : m_size(0) { check_template_parameters(); resize(size); }
 
+    EIGEN_DEVICE_FUNC
     inline SparseVector(Index rows, Index cols) : m_size(0) { check_template_parameters(); resize(rows,cols); }
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline SparseVector(const SparseMatrixBase<OtherDerived>& other)
       : m_size(0)
     {
@@ -273,6 +310,7 @@ class SparseVector
       *this = other.derived();
     }
 
+    EIGEN_DEVICE_FUNC
     inline SparseVector(const SparseVector& other)
       : Base(other), m_size(0)
     {
@@ -284,20 +322,23 @@ class SparseVector
       * Overloaded for performance: this version performs a \em shallow swap by swapping pointers and attributes only.
       * \sa SparseMatrixBase::swap()
       */
+    EIGEN_DEVICE_FUNC
     inline void swap(SparseVector& other)
     {
-      std::swap(m_size, other.m_size);
+      numext::swap(m_size, other.m_size);
       m_data.swap(other.m_data);
     }
 
     template<int OtherOptions>
+    EIGEN_DEVICE_FUNC
     inline void swap(SparseMatrix<Scalar,OtherOptions,StorageIndex>& other)
     {
       eigen_assert(other.outerSize()==1);
-      std::swap(m_size, other.m_innerSize);
+      numext::swap(m_size, other.m_innerSize);
       m_data.swap(other.m_data);
     }
 
+    EIGEN_DEVICE_FUNC
     inline SparseVector& operator=(const SparseVector& other)
     {
       if (other.isRValue())
@@ -313,6 +354,7 @@ class SparseVector
     }
 
     template<typename OtherDerived>
+    EIGEN_DEVICE_FUNC
     inline SparseVector& operator=(const SparseMatrixBase<OtherDerived>& other)
     {
       SparseVector tmp(other.size());
@@ -323,6 +365,7 @@ class SparseVector
 
     #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename Lhs, typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline SparseVector& operator=(const SparseSparseProduct<Lhs,Rhs>& product)
     {
       return Base::operator=(product);
@@ -338,9 +381,11 @@ class SparseVector
     }
 
     /** Destructor */
+    EIGEN_DEVICE_FUNC
     inline ~SparseVector() {}
 
     /** Overloaded for performance */
+    EIGEN_DEVICE_FUNC
     Scalar sum() const;
 
   public:
@@ -393,7 +438,8 @@ class SparseVector
 #   endif
 
 protected:
-  
+
+    EIGEN_DEVICE_FUNC
     static void check_template_parameters()
     {
       EIGEN_STATIC_ASSERT(NumTraits<StorageIndex>::IsSigned,THE_INDEX_TYPE_MUST_BE_A_SIGNED_TYPE);
@@ -420,18 +466,23 @@ struct evaluator<SparseVector<_Scalar,_Options,_Index> >
     Flags = SparseVectorType::Flags
   };
 
+  EIGEN_DEVICE_FUNC
   evaluator() : Base() {}
   
+  EIGEN_DEVICE_FUNC
   explicit evaluator(const SparseVectorType &mat) : m_matrix(&mat)
   {
     EIGEN_INTERNAL_CHECK_COST_VALUE(CoeffReadCost);
   }
   
+  EIGEN_DEVICE_FUNC
   inline Index nonZerosEstimate() const {
     return m_matrix->nonZeros();
   }
   
+  EIGEN_DEVICE_FUNC
   operator SparseVectorType&() { return m_matrix->const_cast_derived(); }
+  EIGEN_DEVICE_FUNC
   operator const SparseVectorType&() const { return *m_matrix; }
   
   const SparseVectorType *m_matrix;
@@ -439,6 +490,7 @@ struct evaluator<SparseVector<_Scalar,_Options,_Index> >
 
 template< typename Dest, typename Src>
 struct sparse_vector_assign_selector<Dest,Src,SVA_Inner> {
+  EIGEN_DEVICE_FUNC
   static void run(Dest& dst, const Src& src) {
     eigen_internal_assert(src.innerSize()==src.size());
     typedef internal::evaluator<Src> SrcEvaluatorType;
@@ -450,6 +502,7 @@ struct sparse_vector_assign_selector<Dest,Src,SVA_Inner> {
 
 template< typename Dest, typename Src>
 struct sparse_vector_assign_selector<Dest,Src,SVA_Outer> {
+  EIGEN_DEVICE_FUNC
   static void run(Dest& dst, const Src& src) {
     eigen_internal_assert(src.outerSize()==src.size());
     typedef internal::evaluator<Src> SrcEvaluatorType;
@@ -465,6 +518,7 @@ struct sparse_vector_assign_selector<Dest,Src,SVA_Outer> {
 
 template< typename Dest, typename Src>
 struct sparse_vector_assign_selector<Dest,Src,SVA_RuntimeSwitch> {
+  EIGEN_DEVICE_FUNC
   static void run(Dest& dst, const Src& src) {
     if(src.outerSize()==1)  sparse_vector_assign_selector<Dest,Src,SVA_Inner>::run(dst, src);
     else                    sparse_vector_assign_selector<Dest,Src,SVA_Outer>::run(dst, src);

--- a/Eigen/src/SparseCore/SparseView.h
+++ b/Eigen/src/SparseCore/SparseView.h
@@ -51,21 +51,29 @@ public:
   EIGEN_SPARSE_PUBLIC_INTERFACE(SparseView)
   typedef typename internal::remove_all<MatrixType>::type NestedExpression;
 
+  EIGEN_DEVICE_FUNC
   explicit SparseView(const MatrixType& mat, const Scalar& reference = Scalar(0),
                       const RealScalar &epsilon = NumTraits<Scalar>::dummy_precision())
     : m_matrix(mat), m_reference(reference), m_epsilon(epsilon) {}
 
+  EIGEN_DEVICE_FUNC
   inline Index rows() const { return m_matrix.rows(); }
+  EIGEN_DEVICE_FUNC
   inline Index cols() const { return m_matrix.cols(); }
 
+  EIGEN_DEVICE_FUNC
   inline Index innerSize() const { return m_matrix.innerSize(); }
+  EIGEN_DEVICE_FUNC
   inline Index outerSize() const { return m_matrix.outerSize(); }
   
   /** \returns the nested expression */
+  EIGEN_DEVICE_FUNC
   const typename internal::remove_all<MatrixTypeNested>::type&
   nestedExpression() const { return m_matrix; }
   
+  EIGEN_DEVICE_FUNC
   Scalar reference() const { return m_reference; }
+  EIGEN_DEVICE_FUNC
   RealScalar epsilon() const { return m_epsilon; }
   
 protected:
@@ -87,19 +95,21 @@ struct unary_evaluator<SparseView<ArgType>, IteratorBased>
     typedef typename evaluator<ArgType>::InnerIterator EvalIterator;
   public:
     typedef SparseView<ArgType> XprType;
-    
+
     class InnerIterator : public EvalIterator
     {
       protected:
         typedef typename XprType::Scalar Scalar;
       public:
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& sve, Index outer)
           : EvalIterator(sve.m_argImpl,outer), m_view(sve.m_view)
         {
           incrementToNonZero();
         }
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE InnerIterator& operator++()
         {
           EvalIterator::operator++();
@@ -113,6 +123,7 @@ struct unary_evaluator<SparseView<ArgType>, IteratorBased>
         const XprType &m_view;
 
       private:
+        EIGEN_DEVICE_FUNC
         void incrementToNonZero()
         {
           while((bool(*this)) && internal::isMuchSmallerThan(value(), m_view.reference(), m_view.epsilon()))
@@ -127,6 +138,7 @@ struct unary_evaluator<SparseView<ArgType>, IteratorBased>
       Flags = XprType::Flags
     };
     
+    EIGEN_DEVICE_FUNC
     explicit unary_evaluator(const XprType& xpr) : m_argImpl(xpr.nestedExpression()), m_view(xpr) {}
 
   protected:
@@ -150,12 +162,14 @@ struct unary_evaluator<SparseView<ArgType>, IndexBased>
     {
       public:
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE InnerIterator(const unary_evaluator& sve, Index outer)
           : m_sve(sve), m_inner(0), m_outer(outer), m_end(sve.m_view.innerSize())
         {
           incrementToNonZero();
         }
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE InnerIterator& operator++()
         {
           m_inner++;
@@ -163,16 +177,21 @@ struct unary_evaluator<SparseView<ArgType>, IndexBased>
           return *this;
         }
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE Scalar value() const
         {
           return (IsRowMajor) ? m_sve.m_argImpl.coeff(m_outer, m_inner)
                               : m_sve.m_argImpl.coeff(m_inner, m_outer);
         }
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE StorageIndex index() const { return m_inner; }
+        EIGEN_DEVICE_FUNC
         inline Index row() const { return IsRowMajor ? m_outer : index(); }
+        EIGEN_DEVICE_FUNC
         inline Index col() const { return IsRowMajor ? index() : m_outer; }
 
+        EIGEN_DEVICE_FUNC
         EIGEN_STRONG_INLINE operator bool() const { return m_inner < m_end && m_inner>=0; }
 
       protected:
@@ -182,6 +201,7 @@ struct unary_evaluator<SparseView<ArgType>, IndexBased>
         const Index m_end;
 
       private:
+        EIGEN_DEVICE_FUNC
         void incrementToNonZero()
         {
           while((bool(*this)) && internal::isMuchSmallerThan(value(), m_sve.m_view.reference(), m_sve.m_view.epsilon()))
@@ -196,6 +216,7 @@ struct unary_evaluator<SparseView<ArgType>, IndexBased>
       Flags = XprType::Flags
     };
     
+    EIGEN_DEVICE_FUNC
     explicit unary_evaluator(const XprType& xpr) : m_argImpl(xpr.nestedExpression()), m_view(xpr) {}
 
   protected:
@@ -223,6 +244,7 @@ struct unary_evaluator<SparseView<ArgType>, IndexBased>
   *
   * \sa SparseMatrixBase::pruned(), class SparseView */
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 const SparseView<Derived> MatrixBase<Derived>::sparseView(const Scalar& reference,
                                                           const typename NumTraits<Scalar>::Real& epsilon) const
 {
@@ -242,6 +264,7 @@ const SparseView<Derived> MatrixBase<Derived>::sparseView(const Scalar& referenc
   * where \c ref is a meaningful non zero reference value.
   * */
 template<typename Derived>
+EIGEN_DEVICE_FUNC
 const SparseView<Derived>
 SparseMatrixBase<Derived>::pruned(const Scalar& reference,
                                   const RealScalar& epsilon) const

--- a/Eigen/src/SparseCore/TriangularSolver.h
+++ b/Eigen/src/SparseCore/TriangularSolver.h
@@ -30,6 +30,7 @@ struct sparse_solve_triangular_selector<Lhs,Rhs,Mode,Lower,RowMajor>
   typedef typename Rhs::Scalar Scalar;
   typedef evaluator<Lhs> LhsEval;
   typedef typename evaluator<Lhs>::InnerIterator LhsIterator;
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs& lhs, Rhs& other)
   {
     LhsEval lhsEval(lhs);
@@ -67,6 +68,7 @@ struct sparse_solve_triangular_selector<Lhs,Rhs,Mode,Upper,RowMajor>
   typedef typename Rhs::Scalar Scalar;
   typedef evaluator<Lhs> LhsEval;
   typedef typename evaluator<Lhs>::InnerIterator LhsIterator;
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs& lhs, Rhs& other)
   {
     LhsEval lhsEval(lhs);
@@ -106,6 +108,7 @@ struct sparse_solve_triangular_selector<Lhs,Rhs,Mode,Lower,ColMajor>
   typedef typename Rhs::Scalar Scalar;
   typedef evaluator<Lhs> LhsEval;
   typedef typename evaluator<Lhs>::InnerIterator LhsIterator;
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs& lhs, Rhs& other)
   {
     LhsEval lhsEval(lhs);
@@ -141,6 +144,7 @@ struct sparse_solve_triangular_selector<Lhs,Rhs,Mode,Upper,ColMajor>
   typedef typename Rhs::Scalar Scalar;
   typedef evaluator<Lhs> LhsEval;
   typedef typename evaluator<Lhs>::InnerIterator LhsIterator;
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs& lhs, Rhs& other)
   {
     LhsEval lhsEval(lhs);
@@ -175,6 +179,7 @@ struct sparse_solve_triangular_selector<Lhs,Rhs,Mode,Upper,ColMajor>
 
 template<typename ExpressionType,unsigned int Mode>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 void TriangularViewImpl<ExpressionType,Mode,Sparse>::solveInPlace(MatrixBase<OtherDerived>& other) const
 {
   eigen_assert(derived().cols() == derived().rows() && derived().cols() == other.rows());
@@ -213,6 +218,7 @@ struct sparse_solve_triangular_sparse_selector<Lhs,Rhs,Mode,UpLo,ColMajor>
   typedef typename Rhs::Scalar Scalar;
   typedef typename promote_index_type<typename traits<Lhs>::StorageIndex,
                                       typename traits<Rhs>::StorageIndex>::type StorageIndex;
+  EIGEN_DEVICE_FUNC
   static void run(const Lhs& lhs, Rhs& other)
   {
     const bool IsLower = (UpLo==Lower);
@@ -292,6 +298,7 @@ struct sparse_solve_triangular_sparse_selector<Lhs,Rhs,Mode,UpLo,ColMajor>
 #ifndef EIGEN_PARSED_BY_DOXYGEN
 template<typename ExpressionType,unsigned int Mode>
 template<typename OtherDerived>
+EIGEN_DEVICE_FUNC
 void TriangularViewImpl<ExpressionType,Mode,Sparse>::solveInPlace(SparseMatrixBase<OtherDerived>& other) const
 {
   eigen_assert(derived().cols() == derived().rows() && derived().cols() == other.rows());

--- a/Eigen/src/SparseQR/SparseQR.h
+++ b/Eigen/src/SparseQR/SparseQR.h
@@ -104,7 +104,11 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
     };
     
   public:
-    SparseQR () :  m_analysisIsok(false), m_lastError(""), m_useDefaultThreshold(true),m_isQSorted(false),m_isEtreeOk(false)
+    EIGEN_DEVICE_FUNC SparseQR () :  m_analysisIsok(false),
+#if !defined(EIGEN_CUDA_ARCH)
+        m_lastError(""),
+#endif
+        m_useDefaultThreshold(true),m_isQSorted(false),m_isEtreeOk(false)
     { }
     
     /** Construct a QR factorization of the matrix \a mat.
@@ -113,7 +117,11 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       * 
       * \sa compute()
       */
-    explicit SparseQR(const MatrixType& mat) : m_analysisIsok(false), m_lastError(""), m_useDefaultThreshold(true),m_isQSorted(false),m_isEtreeOk(false)
+    EIGEN_DEVICE_FUNC explicit SparseQR(const MatrixType& mat) : m_analysisIsok(false),
+#if !defined(EIGEN_CUDA_ARCH)
+        m_lastError(""),
+#endif
+        m_useDefaultThreshold(true),m_isQSorted(false),m_isEtreeOk(false)
     {
       compute(mat);
     }
@@ -124,21 +132,21 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       * 
       * \sa analyzePattern(), factorize()
       */
-    void compute(const MatrixType& mat)
+    EIGEN_DEVICE_FUNC void compute(const MatrixType& mat)
     {
       analyzePattern(mat);
       factorize(mat);
     }
-    void analyzePattern(const MatrixType& mat);
-    void factorize(const MatrixType& mat);
+    EIGEN_DEVICE_FUNC void analyzePattern(const MatrixType& mat);
+    EIGEN_DEVICE_FUNC void factorize(const MatrixType& mat);
     
     /** \returns the number of rows of the represented matrix. 
       */
-    inline Index rows() const { return m_pmat.rows(); }
+    EIGEN_DEVICE_FUNC inline Index rows() const { return m_pmat.rows(); }
     
     /** \returns the number of columns of the represented matrix. 
       */
-    inline Index cols() const { return m_pmat.cols();}
+    EIGEN_DEVICE_FUNC inline Index cols() const { return m_pmat.cols();}
     
     /** \returns a const reference to the \b sparse upper triangular matrix R of the QR factorization.
       * \warning The entries of the returned matrix are not sorted. This means that using it in algorithms
@@ -153,13 +161,13 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       * SparseMatrix<double>          Rc = Rr;            // column-major, sorted
       * \endcode
       */
-    const QRMatrixType& matrixR() const { return m_R; }
+    EIGEN_DEVICE_FUNC const QRMatrixType& matrixR() const { return m_R; }
     
     /** \returns the number of non linearly dependent columns as determined by the pivoting threshold.
       *
       * \sa setPivotThreshold()
       */
-    Index rank() const
+    EIGEN_DEVICE_FUNC Index rank() const
     {
       eigen_assert(m_isInitialized && "The factorization should be called first, use compute()");
       return m_nonzeropivots; 
@@ -183,12 +191,14 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
     * reflectors are stored unsorted, two transpositions are needed to sort
     * them before performing the product.
     */
+    EIGEN_DEVICE_FUNC
     SparseQRMatrixQReturnType<SparseQR> matrixQ() const 
     { return SparseQRMatrixQReturnType<SparseQR>(*this); }
     
     /** \returns a const reference to the column permutation P that was applied to A such that A*P = Q*R
       * It is the combination of the fill-in reducing permutation and numerical column pivoting.
       */
+    EIGEN_DEVICE_FUNC
     const PermutationType& colsPermutation() const
     { 
       eigen_assert(m_isInitialized && "Decomposition is not initialized.");
@@ -198,10 +208,13 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
     /** \returns A string describing the type of error.
       * This method is provided to ease debugging, not to handle errors.
       */
+#if !defined(EIGEN_CUDA_ARCH)
     std::string lastErrorMessage() const { return m_lastError; }
+#endif
     
     /** \internal */
     template<typename Rhs, typename Dest>
+    EIGEN_DEVICE_FUNC
     bool _solve_impl(const MatrixBase<Rhs> &B, MatrixBase<Dest> &dest) const
     {
       eigen_assert(m_isInitialized && "The factorization should be called first, use compute()");
@@ -232,6 +245,7 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       * In practice, if during the factorization the norm of the column that has to be eliminated is below
       * this threshold, then the entire column is treated as zero, and it is moved at the end.
       */
+    EIGEN_DEVICE_FUNC
     void setPivotThreshold(const RealScalar& threshold)
     {
       m_useDefaultThreshold = false;
@@ -243,6 +257,7 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       * \sa compute()
       */
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<SparseQR, Rhs> solve(const MatrixBase<Rhs>& B) const 
     {
       eigen_assert(m_isInitialized && "The factorization should be called first, use compute()");
@@ -250,6 +265,7 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       return Solve<SparseQR, Rhs>(*this, B.derived());
     }
     template<typename Rhs>
+    EIGEN_DEVICE_FUNC
     inline const Solve<SparseQR, Rhs> solve(const SparseMatrixBase<Rhs>& B) const
     {
           eigen_assert(m_isInitialized && "The factorization should be called first, use compute()");
@@ -265,6 +281,7 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
       *
       * \sa iparm()          
       */
+    EIGEN_DEVICE_FUNC
     ComputationInfo info() const
     {
       eigen_assert(m_isInitialized && "Decomposition is not initialized.");
@@ -273,6 +290,7 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
 
 
     /** \internal */
+    EIGEN_DEVICE_FUNC
     inline void _sort_matrix_Q()
     {
       if(this->m_isQSorted) return;
@@ -287,7 +305,9 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
     bool m_analysisIsok;
     bool m_factorizationIsok;
     mutable ComputationInfo m_info;
+#if !defined(EIGEN_CUDA_ARCH)
     std::string m_lastError;
+#endif
     QRMatrixType m_pmat;            // Temporary matrix
     QRMatrixType m_R;               // The triangular factor matrix
     QRMatrixType m_Q;               // The orthogonal reflectors
@@ -317,6 +337,7 @@ class SparseQR : public SparseSolverBase<SparseQR<_MatrixType,_OrderingType> >
   * \note In this step it is assumed that there is no empty row in the matrix \a mat.
   */
 template <typename MatrixType, typename OrderingType>
+EIGEN_DEVICE_FUNC
 void SparseQR<MatrixType,OrderingType>::analyzePattern(const MatrixType& mat)
 {
   eigen_assert(mat.isCompressed() && "SparseQR requires a sparse matrix in compressed mode. Call .makeCompressed() before passing it to SparseQR");
@@ -358,6 +379,7 @@ void SparseQR<MatrixType,OrderingType>::analyzePattern(const MatrixType& mat)
   * \param mat The sparse column-major matrix
   */
 template <typename MatrixType, typename OrderingType>
+EIGEN_DEVICE_FUNC
 void SparseQR<MatrixType,OrderingType>::factorize(const MatrixType& mat)
 {
   using std::abs;
@@ -449,7 +471,9 @@ void SparseQR<MatrixType,OrderingType>::factorize(const MatrixType& mat)
       StorageIndex st = m_firstRowElt(curIdx); // The traversal of the etree starts here
       if (st < 0 )
       {
+#if !defined(EIGEN_CUDA_ARCH)
         m_lastError = "Empty row found during numerical factorization";
+#endif
         m_info = InvalidInput;
         return;
       }
@@ -465,7 +489,7 @@ void SparseQR<MatrixType,OrderingType>::factorize(const MatrixType& mat)
 
       // Reverse the list to get the topological ordering
       Index nt = nzcolR-bi;
-      for(Index i = 0; i < nt/2; i++) std::swap(Ridx(bi+i), Ridx(nzcolR-i-1));
+      for(Index i = 0; i < nt/2; i++) numext::swap(Ridx(bi+i), Ridx(nzcolR-i-1));
        
       // Copy the current (curIdx,pcol) value of the input matrix
       if(itp) tval(curIdx) = itp.value();
@@ -575,7 +599,7 @@ void SparseQR<MatrixType,OrderingType>::factorize(const MatrixType& mat)
     {
       // Zero pivot found: move implicitly this column to the end
       for (Index j = nonzeroCol; j < n-1; j++) 
-        std::swap(m_pivotperm.indices()(j), m_pivotperm.indices()[j+1]);
+        numext::swap(m_pivotperm.indices()(j), m_pivotperm.indices()[j+1]);
       
       // Recompute the column elimination tree
       internal::coletree(m_pmat, m_etree, m_firstRowElt, m_pivotperm.indices().data());
@@ -615,13 +639,17 @@ struct SparseQR_QProduct : ReturnByValue<SparseQR_QProduct<SparseQRType, Derived
   typedef typename SparseQRType::QRMatrixType MatrixType;
   typedef typename SparseQRType::Scalar Scalar;
   // Get the references 
+  EIGEN_DEVICE_FUNC
   SparseQR_QProduct(const SparseQRType& qr, const Derived& other, bool transpose) : 
   m_qr(qr),m_other(other),m_transpose(transpose) {}
+  EIGEN_DEVICE_FUNC
   inline Index rows() const { return m_qr.matrixQ().rows(); }
+  EIGEN_DEVICE_FUNC
   inline Index cols() const { return m_other.cols(); }
   
   // Assign to a vector
   template<typename DesType>
+  EIGEN_DEVICE_FUNC
   void evalTo(DesType& res) const
   {
     Index m = m_qr.rows();
@@ -679,20 +707,26 @@ struct SparseQRMatrixQReturnType : public EigenBase<SparseQRMatrixQReturnType<Sp
     RowsAtCompileTime = Dynamic,
     ColsAtCompileTime = Dynamic
   };
+  EIGEN_DEVICE_FUNC
   explicit SparseQRMatrixQReturnType(const SparseQRType& qr) : m_qr(qr) {}
   template<typename Derived>
+  EIGEN_DEVICE_FUNC
   SparseQR_QProduct<SparseQRType, Derived> operator*(const MatrixBase<Derived>& other)
   {
     return SparseQR_QProduct<SparseQRType,Derived>(m_qr,other.derived(),false);
   }
   // To use for operations with the adjoint of Q
+  EIGEN_DEVICE_FUNC
   SparseQRMatrixQTransposeReturnType<SparseQRType> adjoint() const
   {
     return SparseQRMatrixQTransposeReturnType<SparseQRType>(m_qr);
   }
+  EIGEN_DEVICE_FUNC
   inline Index rows() const { return m_qr.rows(); }
+  EIGEN_DEVICE_FUNC
   inline Index cols() const { return m_qr.rows(); }
   // To use for operations with the transpose of Q FIXME this is the same as adjoint at the moment
+  EIGEN_DEVICE_FUNC
   SparseQRMatrixQTransposeReturnType<SparseQRType> transpose() const
   {
     return SparseQRMatrixQTransposeReturnType<SparseQRType>(m_qr);
@@ -704,8 +738,10 @@ struct SparseQRMatrixQReturnType : public EigenBase<SparseQRMatrixQReturnType<Sp
 template<typename SparseQRType>
 struct SparseQRMatrixQTransposeReturnType
 {
+  EIGEN_DEVICE_FUNC
   explicit SparseQRMatrixQTransposeReturnType(const SparseQRType& qr) : m_qr(qr) {}
   template<typename Derived>
+  EIGEN_DEVICE_FUNC
   SparseQR_QProduct<SparseQRType,Derived> operator*(const MatrixBase<Derived>& other)
   {
     return SparseQR_QProduct<SparseQRType,Derived>(m_qr,other.derived(), true);
@@ -729,6 +765,7 @@ struct Assignment<DstXprType, SparseQRMatrixQReturnType<SparseQRType>, internal:
   typedef SparseQRMatrixQReturnType<SparseQRType> SrcXprType;
   typedef typename DstXprType::Scalar Scalar;
   typedef typename DstXprType::StorageIndex StorageIndex;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &/*func*/)
   {
     typename DstXprType::PlainObject idMat(src.rows(), src.cols());
@@ -745,6 +782,7 @@ struct Assignment<DstXprType, SparseQRMatrixQReturnType<SparseQRType>, internal:
   typedef SparseQRMatrixQReturnType<SparseQRType> SrcXprType;
   typedef typename DstXprType::Scalar Scalar;
   typedef typename DstXprType::StorageIndex StorageIndex;
+  EIGEN_DEVICE_FUNC
   static void run(DstXprType &dst, const SrcXprType &src, const internal::assign_op<Scalar,Scalar> &/*func*/)
   {
     dst = src.m_qr.matrixQ() * DstXprType::Identity(src.m_qr.rows(), src.m_qr.rows());

--- a/Eigen/src/plugins/IndexedViewMethods.h
+++ b/Eigen/src/plugins/IndexedViewMethods.h
@@ -36,18 +36,21 @@ struct IvcType : public internal::IndexedViewCompatibleType<Indices,SizeAtCompil
 typedef typename internal::IndexedViewCompatibleType<Index,1>::type IvcIndex;
 
 template<typename Indices>
+EIGEN_DEVICE_FUNC
 typename IvcRowType<Indices>::type
 ivcRow(const Indices& indices) const {
   return internal::makeIndexedViewCompatible(indices, internal::variable_if_dynamic<Index,RowsAtCompileTime>(derived().rows()),Specialized);
 }
 
 template<typename Indices>
+EIGEN_DEVICE_FUNC
 typename IvcColType<Indices>::type
 ivcCol(const Indices& indices) const {
   return internal::makeIndexedViewCompatible(indices, internal::variable_if_dynamic<Index,ColsAtCompileTime>(derived().cols()),Specialized);
 }
 
 template<typename Indices>
+EIGEN_DEVICE_FUNC
 typename IvcColType<Indices>::type
 ivcSize(const Indices& indices) const {
   return internal::makeIndexedViewCompatible(indices, internal::variable_if_dynamic<Index,SizeAtCompileTime>(derived().size()),Specialized);
@@ -67,6 +70,7 @@ struct EIGEN_INDEXED_VIEW_METHOD_TYPE {
 // This is the generic version
 
 template<typename RowIndices, typename ColIndices>
+EIGEN_DEVICE_FUNC
 typename internal::enable_if<internal::valid_indexed_view_overload<RowIndices,ColIndices>::value
   && internal::traits<typename EIGEN_INDEXED_VIEW_METHOD_TYPE<RowIndices,ColIndices>::type>::ReturnAsIndexedView,
   typename EIGEN_INDEXED_VIEW_METHOD_TYPE<RowIndices,ColIndices>::type >::type


### PR DESCRIPTION
When moving CMSSW from running against cms/master/d812f411c3f9 to this branch, some CUDA fixes were lost. This leads to compilation issues as described in https://github.com/cms-sw/cmssw/issues/33797

This PR re-imports and adapt the modifications in branch cms/master/d812f411c3f9 release and fixes this issue.