### PR TITLE
Re-adding last commit of "Re-import and update of Eigen patches for CUDA" #4

### DIFF
--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -1312,6 +1312,7 @@ struct lhs_process_one_packet
 {
   typedef typename GEBPTraits::RhsPacketx4 RhsPacketx4;
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void peeled_kc_onestep(Index K, const LhsScalar* blA, const RhsScalar* blB, GEBPTraits traits, LhsPacket *A0, RhsPacketx4 *rhs_panel, RhsPacket *T0, AccPacket *C0, AccPacket *C1, AccPacket *C2, AccPacket *C3)
   {
     EIGEN_ASM_COMMENT("begin step of gebp micro kernel 1X4");
@@ -1328,6 +1329,7 @@ struct lhs_process_one_packet
     EIGEN_ASM_COMMENT("end step of gebp micro kernel 1X4");
   }
 
+  EIGEN_DEVICE_FUNC
   EIGEN_STRONG_INLINE void operator()(
     const DataMapper& res, const LhsScalar* blockA, const RhsScalar* blockB, ResScalar alpha,
     Index peelStart, Index peelEnd, Index strideA, Index strideB, Index offsetA, Index offsetB,


### PR DESCRIPTION
The currently active version of Eigen (branch `cms-externals/cms/master/f612df273689a19d25b45ca4f8269463207c4fee`, used in `CMSSW_12_1_0_pre1` misses one commit from #4 (the other ones have been cherry picked). This PR re-imports this commit and solves the issue raised in https://github.com/cms-sw/cmssw/issues/33797 (https://github.com/cms-sw/cmssw/issues/33797#issuecomment-890312996).