### PR TITLE
Revert "fix for vec_cmpne of power9"

### DIFF
--- a/Eigen/src/Core/arch/AltiVec/PacketMath.h
+++ b/Eigen/src/Core/arch/AltiVec/PacketMath.h
@@ -30,13 +30,7 @@ namespace internal {
 #ifndef EIGEN_ARCH_DEFAULT_NUMBER_OF_REGISTERS
 #define EIGEN_ARCH_DEFAULT_NUMBER_OF_REGISTERS  32
 #endif
-	
-// power9 yaya, not equal
-#ifndef vec_cmpne
-#  define vec_not(a) vec_nor(a, a)
-#  define vec_cmpne(a, b) vec_not(vec_cmpeq(a, b))
-#endif
-	
+
 typedef __vector float                   Packet4f;
 typedef __vector int                     Packet4i;
 typedef __vector unsigned int            Packet4ui;


### PR DESCRIPTION
This reverts commit 4ad2a6cf17758d5a249fa78829810233222c8294.

Should no longer be needed with GCC 8 and later.